### PR TITLE
Use ANSI Escape Codes for Title

### DIFF
--- a/src/aniworld/__main__.py
+++ b/src/aniworld/__main__.py
@@ -1,16 +1,9 @@
-import ctypes
-import platform
-
 from aniworld.entry import aniworld
 from aniworld.config import VERSION
 
 
 def main():
-    if platform.system() == "Windows":
-        ctypes.windll.kernel32.SetConsoleTitleW(
-            f"AniWorld-Downloader {VERSION}"
-        )
-
+    print(f"\033]0;AniWorld-Downloader {VERSION}\007", end='', flush=True)
     aniworld()
 
 


### PR DESCRIPTION
Now the title will be set OS independent.
Note: this will not work below Windows 10, you would need to add the ctypes call back if you want to support that.
Should I do that [Yes/No]?