### PR TITLE
Improved search by handling JSONDecodeError instead of returning Error

### DIFF
--- a/src/aniworld/search.py
+++ b/src/aniworld/search.py
@@ -32,12 +32,12 @@ def search_anime(keyword: str = None) -> str:
     return curses.wrapper(show_menu, anime_list)
 
 
-def fetch_animes(url):
+def fetch_anime_list(url: str) -> list:
     response = requests.get(url, timeout=DEFAULT_REQUEST_TIMEOUT)
     response.raise_for_status()
-    
+
     clean_text = response.text.strip()
-    
+
     try:
         decoded_data = json.loads(html.unescape(clean_text))
         return decoded_data if isinstance(decoded_data, list) else []

--- a/src/aniworld/search.py
+++ b/src/aniworld/search.py
@@ -3,6 +3,7 @@ import html
 import webbrowser
 from urllib.parse import quote
 import logging
+import re
 
 import curses
 import requests
@@ -31,16 +32,26 @@ def search_anime(keyword: str = None) -> str:
     return curses.wrapper(show_menu, anime_list)
 
 
-def fetch_anime_list(url: str) -> list:
+def fetch_animes(url):
+    response = requests.get(url, timeout=DEFAULT_REQUEST_TIMEOUT)
+    response.raise_for_status()
+    
+    clean_text = response.text.strip()
+    
     try:
-        response = requests.get(url, timeout=DEFAULT_REQUEST_TIMEOUT)
-        response.raise_for_status()
-        decoded_data = json.loads(html.unescape(response.text))
-        if isinstance(decoded_data, list):
-            return decoded_data
-        return []
-    except (requests.RequestException, json.JSONDecodeError) as exc:
-        raise ValueError("Could not get valid anime: ") from exc
+        decoded_data = json.loads(html.unescape(clean_text))
+        return decoded_data if isinstance(decoded_data, list) else []
+    except json.JSONDecodeError:
+        try:
+            # Remove BOM and problematic characters
+            clean_text = clean_text.encode('utf-8').decode('utf-8-sig')
+            # Remove problematic characters
+            clean_text = re.sub(r'[\x00-\x1F\x7F-\x9F]', '', clean_text)
+            # Parse the new text
+            decoded_data = json.loads(clean_text)
+            return decoded_data if isinstance(decoded_data, list) else []
+        except (requests.RequestException, json.JSONDecodeError) as exc:
+            raise ValueError("Could not get valid anime: ") from exc
 
 
 def show_menu(stdscr: curses.window, options: list) -> str:


### PR DESCRIPTION
Fixed search by handling returned objects more correctly.

For example, searching for "monster" causes this error for me:
`ValueError: Could not get valid anime: `
which is caused by:
`json.decoder.JSONDecodeError: Expecting ',' delimiter: line 1 column 3039 (char 3038)`

I changed the `fetch_anime_list` function, which now handles the object correctly if its not loaded correctly.
```py
def fetch_anime_list(url: str) -> list:
    response = requests.get(url, timeout=DEFAULT_REQUEST_TIMEOUT)
    response.raise_for_status()

    clean_text = response.text.strip()

    try:
        decoded_data = json.loads(html.unescape(clean_text))
        return decoded_data if isinstance(decoded_data, list) else []
    except json.JSONDecodeError:
        try:
            # Remove BOM and problematic characters
            clean_text = clean_text.encode('utf-8').decode('utf-8-sig')
            # Remove problematic characters
            clean_text = re.sub(r'[\x00-\x1F\x7F-\x9F]', '', clean_text)
            # Parse the new text
            decoded_data = json.loads(clean_text)
            return decoded_data if isinstance(decoded_data, list) else []
        except (requests.RequestException, json.JSONDecodeError) as exc:
            raise ValueError("Could not get valid anime: ") from exc
```

The function now returns the expected output:
`[{'name': 'Monster Girl Doctor', 'link': 'monster-girl-doctor', 'descriptio...`