### PR TITLE
fixed voe forbidden direct link

### DIFF
--- a/src/aniworld/config.py
+++ b/src/aniworld/config.py
@@ -172,7 +172,8 @@ SUPPORTED_PROVIDERS = (
 @lru_cache(maxsize=1)
 def get_random_user_agent():
     """Get random user agent with caching to avoid repeated UserAgent() calls"""
-    return UserAgent().random
+    ua = UserAgent(os=["Windows", "Mac OS X"])
+    return ua.random
 
 
 # Backward compatibility - keep RANDOM_USER_AGENT as a constant


### PR DESCRIPTION
i changes the random user agent generator to only use Windows and Mac OS X as operating systems for the user agents.
By doing this the issue with getting a forbidden link by voe is resolved