### PR TITLE
Fix SSL CERTIFICATE_VERIFY_FAILED error on download

### DIFF
--- a/src/aniworld/action/download.py
+++ b/src/aniworld/action/download.py
@@ -29,6 +29,7 @@ def _build_ytdl_command(direct_link: str, output_path: str, anime: Anime) -> Lis
     command = [
         "yt-dlp",
         direct_link,
+        "--no-check-certificate",
         "--fragment-retries",
         "infinite",
         "--concurrent-fragments",


### PR DESCRIPTION
Added --no-check-certificate parameter for yt-dlp command