### PR TITLE
Fix Windows compatibility: Add support for fcntl and termios modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ dependencies = [
     'jsbeautifier',
     'flask',
     'py-cpuinfo; platform_system == "Windows"',
-    'windows-curses; platform_system == "Windows"'
+    'windows-curses; platform_system == "Windows"',
+    'winfcntl; platform_system == "Windows"'
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/aniworld/menu.py
+++ b/src/aniworld/menu.py
@@ -3,8 +3,16 @@ import logging
 import os
 import sys
 import struct
-import fcntl
-import termios
+import sys
+if sys.platform == "win32":
+    import winfcntl as fcntl
+    # termios existiert nicht unter Windows, definiere TIOCGWINSZ als None
+    class MockTermios:
+        TIOCGWINSZ = None
+    termios = MockTermios()
+else:
+    import fcntl
+    import termios
 from typing import Dict, List, Optional, Tuple, Any
 
 import urllib3


### PR DESCRIPTION
## 🔧 Bug Fix: Windows Compatibility

### Problem
The application failed to run on Windows due to missing Unix-specific modules:
- `fcntl` module is not available on Windows
- `termios` module is not available on Windows

This caused `ImportError` when trying to run the application on Windows systems.

### Solution
- ✅ **Conditional imports**: Added platform-specific imports for `fcntl`/`winfcntl`
- ✅ **Mock termios**: Created `MockTermios` class to handle missing `termios.TIOCGWINSZ` on Windows
- ✅ **Dependencies**: Added `winfcntl` as Windows-specific dependency in `pyproject.toml`
- ✅ **Cross-platform**: Maintained full compatibility with Unix/Linux systems

### Changes
- **`src/aniworld/menu.py`**: Added conditional imports and `MockTermios` class
- **`pyproject.toml`**: Added `winfcntl; platform_system == "Windows"` dependency

### Testing
- [x] Code works on Windows with `winfcntl` 
- [x] Code maintains compatibility with Unix/Linux systems
- [x] Terminal size detection fallbacks work correctly

### Related Issues
Fixes issues where Windows users couldn't run the application due to Unix-specific module imports.
#96 