### PR TITLE
Remove instead of replacing illegal characters in file names

### DIFF
--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -44,7 +44,7 @@ FORBIDDEN_CHARS = re.compile(r'[<>:"/\\|?*]')
 
 def clean_title(title: str) -> str:
     """Clean a string to make it safe for use as a filename."""
-    return FORBIDDEN_CHARS.sub("_", title).strip()
+    return FORBIDDEN_CHARS.sub("", title).strip()
 
 
 def check_downloaded(episode_path):


### PR DESCRIPTION
As the title suggests, instead of replacing illegal characters in file names with an underscore, they are now removed. 

The replacement with an underscore annoyed me, because this wasn’t the case before v4 and in my honest opinion, it makes them look ugly because of a mix of underscores and spaces (Example: `Frieren_ Beyond Journey's End` used to be `Frieren Beyond Journey's End`).