### PR TITLE
Add English Dub to CLI language choices

### DIFF
--- a/src/aniworld/config.py
+++ b/src/aniworld/config.py
@@ -194,12 +194,14 @@ LANG_KEY_MAP = {
     "1": (Audio.GERMAN, Subtitles.NONE),  # German Dub
     "2": (Audio.JAPANESE, Subtitles.ENGLISH),  # English Sub
     "3": (Audio.JAPANESE, Subtitles.GERMAN),  # German Sub
+    "4": (Audio.ENGLISH, Subtitles.NONE),  # English Dub
 }
 
 LANG_LABELS = {
     "1": "German Dub",
     "2": "English Sub",
     "3": "German Sub",
+    "4": "English Dub",
 }
 
 LANG_CODE_MAP = {


### PR DESCRIPTION
Added "English Dub" as key to both `LANG_KEY_MAP` and `LANG_LABELS` Now `--language 'English Dub'` passes argparse validation and reaches the S.to model, which already knew how to handle it.