### PR TITLE
feat: add sync path feature with environment variable support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # Default download directory used by the application
 ENV ANIWORLD_DOWNLOAD_PATH=/app/Downloads
 
+# Default sync directory used by the application
+ENV ANIWORLD_SYNC_PATH=/app/Sync
+
 # Copy packaging metadata first to maximize Docker layer cache hits for dependency installs
 COPY pyproject.toml /app/
 COPY README.md LICENSE MANIFEST.in /app/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,13 +7,16 @@ services:
     volumes:
       # Persist downloads on the host so they survive container recreation.
       - ./Downloads:/app/Downloads
+      - ./Sync:/app/Sync
       # Persist application config and auth database across restarts.
       - aniworld-data:/home/aniworld/.aniworld
 
     # NOTE: Create ./Downloads before running: mkdir -p Downloads
     # Docker creates missing bind-mount directories as root, causing permission errors.
 
-    # environment:
+    environment:
+      - ANIWORLD_DOWNLOAD_PATH=/app/Downloads
+      - ANIWORLD_SYNC_PATH=/app/Sync
     # --- General settings (uncomment the environment block to customise) ---
     #   ANIWORLD_LANGUAGE: "German Dub"               # Default language (German Dub | English Sub | German Sub | English Dub)
     #   ANIWORLD_PROVIDER: "VOE"                      # Default streaming provider

--- a/src/aniworld/.env.example
+++ b/src/aniworld/.env.example
@@ -6,6 +6,10 @@
 # Example: Downloads
 ANIWORLD_DOWNLOAD_PATH=Downloads
 
+# Where sync files are saved (relative from home or absolute path).
+# Example: Sync
+ANIWORLD_SYNC_PATH=Sync
+
 # Folder used for app data/cache/config (relative to the download path).
 # Example: .aniworld
 ANIWORLD_INSTALL_FOLDER=.aniworld

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -282,20 +282,27 @@ def _run_autosync_for_job(job):
                 target_lang, target_lang.lower().replace(" ", "-")
             )
 
-            raw = os.environ.get("ANIWORLD_DOWNLOAD_PATH", "")
-            if raw:
-                dl_base = Path(raw).expanduser()
-                if not dl_base.is_absolute():
-                    dl_base = Path.home() / dl_base
+            sync_raw = os.environ.get("ANIWORLD_SYNC_PATH", "")
+            if sync_raw:
+                sync_base = Path(sync_raw).expanduser()
+                if not sync_base.is_absolute():
+                    sync_base = Path.home() / sync_base
+            else:
+                sync_base = Path.home() / "Downloads"
+
+            dl_raw = os.environ.get("ANIWORLD_DOWNLOAD_PATH", "")
+            if dl_raw:
+                dl_base = Path(dl_raw).expanduser()
             else:
                 dl_base = Path.home() / "Downloads"
 
-            scan_roots = [dl_base]
+            scan_roots = [sync_base, dl_base]
             for cp in get_custom_paths():
                 cp_path = Path(cp["path"]).expanduser()
                 if not cp_path.is_absolute():
                     cp_path = Path.home() / cp_path
-                scan_roots.append(cp_path)
+                if cp_path not in scan_roots:
+                    scan_roots.append(cp_path)
 
             # Build set of downloaded (season, episode) on disk
             downloaded_eps = set()
@@ -730,16 +737,16 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             lang_sep = os.environ.get("ANIWORLD_LANG_SEPARATION", "0") == "1"
             lang_folders = ["german-dub", "english-sub", "german-sub", "english-dub"]
 
-            raw = os.environ.get("ANIWORLD_DOWNLOAD_PATH", "")
+            raw = os.environ.get("ANIWORLD_SYNC_PATH", "")
             if raw:
-                dl_base = Path(raw).expanduser()
-                if not dl_base.is_absolute():
-                    dl_base = Path.home() / dl_base
+                sync_base = Path(raw).expanduser()
+                if not sync_base.is_absolute():
+                    sync_base = Path.home() / sync_base
             else:
-                dl_base = Path.home() / "Downloads"
+                sync_base = Path.home() / "Downloads"
 
             # Collect all scan roots: default + custom paths
-            scan_roots = [dl_base]
+            scan_roots = [sync_base]
             for cp in get_custom_paths():
                 cp_path = Path(cp["path"]).expanduser()
                 if not cp_path.is_absolute():
@@ -1073,6 +1080,8 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
         data = request.get_json(silent=True) or {}
         if "download_path" in data:
             os.environ["ANIWORLD_DOWNLOAD_PATH"] = str(data["download_path"]).strip()
+        if "sync_path" in data:
+            os.environ["ANIWORLD_SYNC_PATH"] = str(data["sync_path"]).strip()
         if "lang_separation" in data:
             os.environ["ANIWORLD_LANG_SEPARATION"] = (
                 "1" if data["lang_separation"] else "0"

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -282,25 +282,28 @@ def _run_autosync_for_job(job):
                 target_lang, target_lang.lower().replace(" ", "-")
             )
 
-            sync_raw = os.environ.get("ANIWORLD_SYNC_PATH", "")
-            if sync_raw:
-                sync_base = Path(sync_raw).expanduser()
-                if not sync_base.is_absolute():
-                    sync_base = Path.home() / sync_base
-            else:
-                sync_base = Path.home() / "Downloads"
-
             dl_raw = os.environ.get("ANIWORLD_DOWNLOAD_PATH", "")
             if dl_raw:
                 dl_base = Path(dl_raw).expanduser()
             else:
                 dl_base = Path.home() / "Downloads"
 
-            scan_roots = [sync_base, dl_base]
+            scan_roots = [dl_base]
+
+            sync_raw = os.environ.get("ANIWORLD_SYNC_PATH", "")
+            if sync_raw:
+                sync_base = Path(sync_raw).expanduser()
+                if not sync_base.is_absolute():
+                    sync_base = Path.home() / sync_base
+                
+                if sync_base not in scan_roots:
+                    scan_roots.append(sync_base)
+
             for cp in get_custom_paths():
                 cp_path = Path(cp["path"]).expanduser()
                 if not cp_path.is_absolute():
                     cp_path = Path.home() / cp_path
+                
                 if cp_path not in scan_roots:
                     scan_roots.append(cp_path)
 

--- a/src/aniworld/web/static/settings.js
+++ b/src/aniworld/web/static/settings.js
@@ -6,11 +6,15 @@ const syncScheduleSelect = document.getElementById("syncSchedule");
 const syncLanguageSelect = document.getElementById("syncLanguage");
 const syncProviderSelect = document.getElementById("syncProvider");
 
+//Sync path settings
+const syncPathInput = document.getElementById("syncPath");
+
 async function loadSettings() {
   try {
     const resp = await fetch("/api/settings");
     const data = await resp.json();
     downloadPathInput.value = data.download_path || "";
+    syncPathInput.value = data.sync_path || "";
     if (langSeparationCb)
       langSeparationCb.checked = data.lang_separation === "1";
     if (disableEnglishSubCb)
@@ -104,6 +108,25 @@ async function saveDisableEnglishSub() {
     );
   } catch (e) {
     showToast("Failed to save setting: " + e.message);
+  }
+}
+
+async function saveSyncPath() {
+  const sync_path = syncPathInput.value.trim();
+  try {
+    const resp = await fetch("/api/settings", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sync_path }),
+    });
+    const data = await resp.json();
+    if (data.error) {
+      showToast(data.error);
+      return;
+    }
+    showToast("Sync path saved");
+  } catch (e) {
+    showToast("Failed to save settings: " + e.message);
   }
 }
 

--- a/src/aniworld/web/templates/settings.html
+++ b/src/aniworld/web/templates/settings.html
@@ -137,6 +137,10 @@ endblock %} {% block content %}
       How often Auto-Sync checks for new episodes. Language and provider are
       defaults used when creating new sync jobs.
     </div>
+    <div class="settings-row">
+      <input type="text" id="syncPath" placeholder="/path/to/sync" />
+        <button onclick="saveSyncPath()">Save</button>
+    </div>
   </div>
   <div class="settings-section">
     <h2>Settings</h2>


### PR DESCRIPTION
Feature: Dual Path Support for Downloads and Archive Synchronization
Description
This pull request introduces a secondary synchronization path (SYNC_PATH) to complement the default download directory. This allows for a clean separation between active downloads and a permanent media library (archive). The system now monitors both locations to prevent redundant downloads of episodes already present in the long-term storage.

Technical Changes
Dual-Path Scanning Logic: The application now constructs a scan_roots list. It starts with the DOWNLOAD_PATH and appends the SYNC_PATH if defined. This ensures that the auto-sync job acknowledges files in both locations.

Environment Variable Integration: Added support for ANIWORLD_SYNC_PATH within the Docker environment configuration.

Web UI Enhancements: * Added a new input field in the settings panel to configure and display the synchronization path.

Implemented asynchronous loading of the sync path via the /api/settings endpoint to ensure the UI reflects the current backend configuration.

Path Normalization: Improved handling of absolute and relative paths, including user home expansion (~) and duplicate prevention within the scanning routine.