### PR TITLE
feat: add per-episode custom provider URL override

### DIFF
--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -175,6 +175,12 @@ def _queue_worker():
 
             from ..playwright import captcha as _captcha_mod
 
+            url_overrides = {}
+            try:
+                url_overrides = json.loads(item.get("url_overrides") or "{}")
+            except Exception:
+                pass
+
             for i, ep_url in enumerate(episodes):
                 update_queue_progress(item["id"], i, ep_url)
                 try:
@@ -187,6 +193,17 @@ def _queue_worker():
                     if selected_path:
                         ep_kwargs["selected_path"] = selected_path
                     episode = prov.episode_cls(**ep_kwargs)
+                    # Inject custom provider URL override if set for this episode
+                    override_url = url_overrides.get(ep_url)
+                    if override_url:
+                        try:
+                            episode._AniworldEpisode__provider_url = override_url
+                        except AttributeError:
+                            pass
+                        try:
+                            episode._SerienstreamEpisode__provider_url = override_url
+                        except AttributeError:
+                            pass
                     _captcha_mod._local.queue_id = item["id"]
                     try:
                         episode.download()
@@ -896,6 +913,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                 )
 
         custom_path_id = data.get("custom_path_id")
+        url_overrides = data.get("url_overrides") or {}
 
         queue_id = add_to_queue(
             title,
@@ -905,6 +923,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             provider,
             username,
             custom_path_id=custom_path_id,
+            url_overrides=url_overrides,
         )
         return jsonify({"queue_id": queue_id})
 

--- a/src/aniworld/web/db.py
+++ b/src/aniworld/web/db.py
@@ -272,6 +272,13 @@ def init_queue_db():
             conn.execute("ALTER TABLE download_queue ADD COLUMN captcha_url TEXT")
         except Exception:
             pass  # column already exists
+        # Add url_overrides column (migration for existing DBs)
+        try:
+            conn.execute(
+                "ALTER TABLE download_queue ADD COLUMN url_overrides TEXT NOT NULL DEFAULT '{}'"
+            )
+        except Exception:
+            pass  # column already exists
         conn.commit()
     finally:
         conn.close()
@@ -286,14 +293,15 @@ def add_to_queue(
     username=None,
     custom_path_id=None,
     source="manual",
+    url_overrides=None,
 ):
     import json
 
     conn = get_db()
     try:
         cur = conn.execute(
-            "INSERT INTO download_queue (title, series_url, episodes, total_episodes, language, provider, username, custom_path_id, source) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO download_queue (title, series_url, episodes, total_episodes, language, provider, username, custom_path_id, source, url_overrides) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 title,
                 series_url,
@@ -304,6 +312,7 @@ def add_to_queue(
                 username,
                 custom_path_id,
                 source,
+                json.dumps(url_overrides or {}),
             ),
         )
         row_id = cur.lastrowid

--- a/src/aniworld/web/static/app.js
+++ b/src/aniworld/web/static/app.js
@@ -29,6 +29,8 @@ let currentSeriesTitle = "";
 let currentSeriesUrl = "";
 // Provider data per language label
 let availableProviders = null;
+// Custom provider URL overrides: episodeUrl -> custom VOE/provider URL
+let episodeUrlOverrides = {};
 // Static list of providers rendered into the template
 const staticProviders = Array.from(providerSelect.options).map((o) => o.value);
 
@@ -344,6 +346,7 @@ async function openSeries(url) {
   seasonAccordion.innerHTML = "";
   statusBar.classList.remove("active");
   availableProviders = null;
+  episodeUrlOverrides = {};
   currentSeriesUrl = url;
   currentSeriesTitle = "";
   await checkLangSeparation();
@@ -445,7 +448,7 @@ function buildAccordion(seasons) {
         const dlIcon = ep.downloaded
           ? '<span class="ep-downloaded" title="Downloaded">&#10003;</span>'
           : "";
-        div.innerHTML = `<input type="checkbox" value="${esc(ep.url)}" data-season="${index}"><span class="ep-num">E${ep.episode_number}</span>${dlIcon}<span class="ep-title">${esc(title)}</span>`;
+        div.innerHTML = `<input type="checkbox" value="${esc(ep.url)}" data-season="${index}"><span class="ep-num">E${ep.episode_number}</span>${dlIcon}<span class="ep-title">${esc(title)}</span><button class="ep-url-btn" title="Custom provider URL" onclick="openUrlOverride(event, '${esc(ep.url)}')">&#128279;</button><span class="ep-url-indicator" id="ep-override-${btoa(ep.url).replace(/=/g,'')}"></span>`;
         body.appendChild(div);
       });
 
@@ -599,6 +602,14 @@ async function startDownload(all) {
     if (customPathSelect && customPathSelect.value) {
       dlBody.custom_path_id = parseInt(customPathSelect.value);
     }
+    // Only include overrides for episodes that are actually being downloaded
+    const relevantOverrides = {};
+    episodes.forEach((u) => {
+      if (episodeUrlOverrides[u]) relevantOverrides[u] = episodeUrlOverrides[u];
+    });
+    if (Object.keys(relevantOverrides).length) {
+      dlBody.url_overrides = relevantOverrides;
+    }
     const resp = await fetch("/api/download", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -626,6 +637,63 @@ function closeModal() {
 }
 function closeModalOutside(e) {
   if (e.target === overlay) closeModal();
+}
+
+function openUrlOverride(event, epUrl) {
+  event.stopPropagation();
+  const safeKey = btoa(epUrl).replace(/=/g, "");
+
+  // Toggle: if panel already open for this episode, close it
+  const existing = document.getElementById("ep-override-panel-" + safeKey);
+  if (existing) { existing.remove(); return; }
+
+  // Close any other open panels first
+  document.querySelectorAll(".ep-override-panel").forEach((p) => p.remove());
+
+  const epItem = event.target.closest(".episode-item");
+  if (!epItem) return;
+
+  const panel = document.createElement("div");
+  panel.className = "ep-override-panel";
+  panel.id = "ep-override-panel-" + safeKey;
+
+  const current = episodeUrlOverrides[epUrl] || "";
+  panel.innerHTML =
+    `<input class="ep-override-input" type="text" placeholder="Provider URL (e.g. https://voe.sx/e/...)" value="${esc(current)}">` +
+    `<button class="ep-override-save">Save</button>` +
+    `<button class="ep-override-clear">Remove</button>`;
+
+  // Insert right after the episode item
+  epItem.insertAdjacentElement("afterend", panel);
+
+  const inputEl = panel.querySelector(".ep-override-input");
+  inputEl.focus();
+  inputEl.select();
+
+  function save() {
+    const trimmed = inputEl.value.trim();
+    const indicator = document.getElementById("ep-override-" + safeKey);
+    if (trimmed) {
+      episodeUrlOverrides[epUrl] = trimmed;
+      if (indicator) { indicator.textContent = "\uD83D\uDD17"; indicator.title = trimmed; }
+    } else {
+      delete episodeUrlOverrides[epUrl];
+      if (indicator) { indicator.textContent = ""; indicator.title = ""; }
+    }
+    panel.remove();
+  }
+
+  panel.querySelector(".ep-override-save").addEventListener("click", save);
+  panel.querySelector(".ep-override-clear").addEventListener("click", () => {
+    delete episodeUrlOverrides[epUrl];
+    const indicator = document.getElementById("ep-override-" + safeKey);
+    if (indicator) { indicator.textContent = ""; indicator.title = ""; }
+    panel.remove();
+  });
+  inputEl.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") save();
+    if (e.key === "Escape") panel.remove();
+  });
 }
 
 // Auto-Sync toggle from modal checkbox

--- a/src/aniworld/web/static/style.css
+++ b/src/aniworld/web/static/style.css
@@ -530,6 +530,87 @@ h1 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1;
+}
+.ep-url-btn {
+  margin-left: 8px;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85rem;
+  opacity: 0.35;
+  padding: 0 2px;
+  line-height: 1;
+  transition: opacity 0.15s;
+}
+.ep-url-btn:hover {
+  opacity: 1;
+}
+.ep-url-indicator {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  color: #6ea8fe;
+  cursor: default;
+}
+.ep-override-panel {
+  display: flex;
+  gap: 8px;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  align-items: center;
+}
+.ep-override-input {
+  flex: 1;
+  padding: 9px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #e0e0e0;
+  font-size: 0.88rem;
+  outline: none;
+  transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
+}
+.ep-override-input:focus {
+  border-color: #2563eb;
+  background: rgba(37, 99, 235, 0.06);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+.ep-override-input::placeholder {
+  color: #555;
+}
+.ep-override-save {
+  padding: 9px 18px;
+  border-radius: 10px;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #fff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 2px 8px rgba(37, 99, 235, 0.25);
+  white-space: nowrap;
+}
+.ep-override-save:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(37, 99, 235, 0.35);
+}
+.ep-override-clear {
+  padding: 9px 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  color: #9ca3af;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+.ep-override-clear:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #e0e0e0;
 }
 
 /* Status bar */


### PR DESCRIPTION
Hello,

I added a feature to manually overide episode link (for dead links f.e. while keeping metadata):

Click on link icon, add and save
<img width="693" height="193" alt="grafik" src="https://github.com/user-attachments/assets/edf83878-19f7-46dc-9f39-e3efc66c90ca" />

Saved
<img width="669" height="84" alt="grafik" src="https://github.com/user-attachments/assets/5e70b910-090b-48ea-bb82-f59051dab025" />

Click scond link icon to edit / remove
<img width="682" height="100" alt="grafik" src="https://github.com/user-attachments/assets/b84923bd-e673-4cb7-8745-99815c4d5810" />

Hope it helps someone!