### PR TITLE
Fix f-string bug in URL assembly

### DIFF
--- a/src/aniworld/models/s_to/series.py
+++ b/src/aniworld/models/s_to/series.py
@@ -300,9 +300,12 @@ class SerienstreamSeries:
         if match:
             raw_url = urljoin(self.url, match.group("url").strip())
             parsed = urlparse(raw_url)
-            return f"{"http://186.2.175.5"}{parsed.path}" + (
-                f"?{parsed.query}" if parsed.query else ""
-            )
+            path = parsed.path
+            if parsed.query:
+                query = f"?{parsed.query}" 
+            else:
+                query = ""
+            return f"http://186.2.175.5{path}" + query
 
         return None
 


### PR DESCRIPTION
Replace the nested f-string with explicit path and query variables when constructing the proxy URL.
Also removed the `{}` wrapped around the IP, which resulted in errors.


```text
 Traceback (most recent call last):
 File "/root/.local/bin/aniworld", line 5, in <module>
 from aniworld.__main__ import main
 File "/root/.local/lib/python3.11/site-packages/aniworld/__init__.py", line 1, in <module>
 from .models.aniworld_to import (
 File "/root/.local/lib/python3.11/site-packages/aniworld/models/__init__.py", line 8, in <module>
 from .s_to import SerienstreamEpisode, SerienstreamSeason, SerienstreamSeries
 File "/root/.local/lib/python3.11/site-packages/aniworld/models/s_to/__init__.py", line 3, in <module>
 from .series import SerienstreamSeries
 File "/root/.local/lib/python3.11/site-packages/aniworld/models/s_to/series.py", line 303
 return f"{"http://186.2.175.5"}{parsed.path}" + (
 ^^^^
 SyntaxError: f-string: expecting '}'
```

