### PR TITLE
ci: rewrite docker-publish workflow with updated actions and v. tag support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,71 +1,52 @@
-name: Build Docker Image
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+name: Build and Publish Docker Image
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
       id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Install the cosign tool
-      # https://github.com/sigstore/cosign-installer
       - name: Install cosign
-        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
-        with:
-          cosign-release: 'v2.2.4'
+        uses: sigstore/cosign-installer@v3
 
-      # Set up BuildKit Docker container builder to be able to build
-      # multi-platform images and export cache
-      # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@v3
 
-      # Login against a Docker registry
-      # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=match,pattern=v\.?(.*),group=1
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
-      # Build and push Docker image with Buildx
-      # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true
@@ -74,16 +55,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Sign the resulting Docker image digest.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
       - name: Sign the published Docker image
         env:
-          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}


### PR DESCRIPTION
 Hey! Thanks for the cool project, been using it with Docker for a while now.

After the newest release (v.4.3.0) I noticed that the Docker image didn't receive any updates, so I looked into it and found that `docker-publish.yml` actually has zero runs ever. The PyPI publish workflow fires on every release just fine, but the Docker one never triggered.

Digging deeper I found two issues:

1. The action versions are pinned to specific SHAs from late 2023, making them hard to maintain and review
2. More importantly, the repo uses a `v.X.Y.Z` tag format (with a dot after `v`), but the default `type=semver` pattern in `docker/metadata-action` expects `vX.Y.Z`, so version tags would never extract correctly

I rewrote the workflow with these fixes:

- Uses `type=match,pattern=v\.?(.*),group=1` to handle the `v.` prefix in tags
- Adds a `latest` tag so the existing `docker-compose.yaml` reference works out of the box
- Bumps all actions to current major versions (`checkout@v4`, `cosign-installer@v3`, `setup-buildx@v3`, `login-action@v3`, `metadata-action@v5`, `build-push-action@v6`)
- Adds `workflow_dispatch` so you can manually trigger a test run without cutting a release
- Keeps cosign signing and GHA build cache

Tested locally with `act release --dryrun` using a fake release event with `tag_name: "v.4.3.0"`, all steps pass.

This is plug and play. No secrets or repo settings needed beyond what's already there (`GITHUB_TOKEN` handles GHCR auth automatically). After merging, you can hit "Run workflow" on the Actions tab to verify it works, or just wait for the next release.