### PR TITLE
fix: mixed content blocking for S.to cover images on HTTPS

### DIFF
--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -495,6 +495,13 @@ def _get_version():
         return ""
 
 
+def _proxy_image_url(url: str) -> str:
+    if not url:
+        return url
+    from urllib.parse import quote
+    return f"/api/proxy-image?url={quote(url, safe='')}"
+
+
 def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
     import os
 
@@ -714,7 +721,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             return jsonify(
                 {
                     "title": series.title,
-                    "poster_url": poster,
+                    "poster_url": _proxy_image_url(poster),
                     "description": getattr(series, "description", ""),
                     "genres": getattr(series, "genres", []),
                     "release_year": getattr(series, "release_year", ""),
@@ -1056,6 +1063,25 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             return jsonify({"url": url})
         return jsonify({"error": "Failed to fetch random anime"}), 500
 
+    @app.route("/api/proxy-image")
+    def api_proxy_image():
+        from flask import Response
+        target = request.args.get("url", "").strip()
+        if not target or not target.startswith(("http://", "https://")):
+            return "", 400
+        try:
+            resp = requests.get(target, timeout=10, stream=True)
+            resp.raise_for_status()
+            content_type = resp.headers.get("Content-Type", "image/jpeg")
+            return Response(
+                resp.iter_content(chunk_size=8192),
+                content_type=content_type,
+                headers={"Cache-Control": "public, max-age=3600"},
+            )
+        except Exception as e:
+            logger.warning(f"Image proxy failed for {target}: {e}")
+            return "", 502
+
     # TTL cache for browse endpoints so long-running instances stay fresh
     import time as _time
 
@@ -1077,28 +1103,32 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
         results = _cached_browse("new_animes", fetch_new_animes)
         if results is None:
             return jsonify({"error": "Failed to fetch new animes"}), 500
-        return jsonify({"results": results})
+        proxied = [{**r, "poster_url": _proxy_image_url(r.get("poster_url", ""))} for r in results]
+        return jsonify({"results": proxied})
 
     @app.route("/api/popular-animes")
     def api_popular_animes():
         results = _cached_browse("popular_animes", fetch_popular_animes)
         if results is None:
             return jsonify({"error": "Failed to fetch popular animes"}), 500
-        return jsonify({"results": results})
+        proxied = [{**r, "poster_url": _proxy_image_url(r.get("poster_url", ""))} for r in results]
+        return jsonify({"results": proxied})
 
     @app.route("/api/new-series")
     def api_new_series():
         results = _cached_browse("new_series", fetch_new_series)
         if results is None:
             return jsonify({"error": "Failed to fetch new series"}), 500
-        return jsonify({"results": results})
+        proxied = [{**r, "poster_url": _proxy_image_url(r.get("poster_url", ""))} for r in results]
+        return jsonify({"results": proxied})
 
     @app.route("/api/popular-series")
     def api_popular_series():
         results = _cached_browse("popular_series", fetch_popular_series)
         if results is None:
             return jsonify({"error": "Failed to fetch popular series"}), 500
-        return jsonify({"results": results})
+        proxied = [{**r, "poster_url": _proxy_image_url(r.get("poster_url", ""))} for r in results]
+        return jsonify({"results": proxied})
 
     @app.route("/api/downloaded-folders")
     def api_downloaded_folders():


### PR DESCRIPTION
### Problem

S.to cover images are served from `http://186.2.175.5` (plain HTTP). When the web UI is accessed over HTTPS (e.g. via a reverse proxy, Tailscale Serve, or any TLS-terminated setup), the browser blocks these image requests as mixed content. The images just fail silently with no error in the UI.

This affects all browse endpoints (`/api/new-series`, `/api/popular-series`, etc.) and the series detail view.

### Root cause

The S.to CDN returns absolute HTTP image URLs. The backend passes these directly to the frontend, which then tries to load them as `<img src="http://...">` from an HTTPS page, which the browser blocks as a security violation.

### Fix

Added a server-side image proxy endpoint (`/api/proxy-image`) that fetches external cover images on behalf of the browser. All `poster_url` values are rewritten to route through this endpoint before being sent to the frontend.

- Browser always requests images from the same HTTPS origin
- Flask fetches the actual image from the CDN over HTTP server-side, so no mixed content restriction applies
- Responses are cached client-side for 1 hour via `Cache-Control`
- Proxy only accepts `http://` and `https://` URLs, returns `400` for anything else
- Downloads are not affected, this only applies to poster images

### Screenshots

**Before (Tailscale HTTPS, broken):**
<img width="922" height="858" alt="screenshot-2026-04-25_10-44-22" src="https://github.com/user-attachments/assets/0735d815-330d-471d-bd1e-81439d01068a" />

**Before (Tailscale HTTPS, broken - DevTools):**
<img width="1906" height="951" alt="screenshot-2026-04-25_10-44-44" src="https://github.com/user-attachments/assets/dfadb900-494d-4810-a30d-2806dab9fa91" />

**After (Tailscale HTTPS, fixed):**
<img width="928" height="830" alt="screenshot-2026-04-25_10-43-54" src="https://github.com/user-attachments/assets/9ddf4c41-1fa3-4053-8d6c-d9bfc6c6f708" />

**After (Tailscale HTTPS, fixed - DevTools):**
<img width="1898" height="942" alt="screenshot-2026-04-25_10-45-28" src="https://github.com/user-attachments/assets/90eb5097-3ae9-4d7f-b6ec-03c1a10d31ad" />


### Testing

Tested locally over plain HTTP (`http://192.168.178.168:8070`) and over HTTPS via Tailscale Serve (`https://aniworld-test.snowy-burbot.ts.net`). Cover images load correctly in both cases. Confirmed `200 OK` with browser cache hits on repeat views.