### PR TITLE
Improve provider fallback and enhance parallel queue downloads

### DIFF
--- a/src/aniworld/.env.example
+++ b/src/aniworld/.env.example
@@ -43,8 +43,15 @@ ANIWORLD_NAMING_TEMPLATE="{title} ({year}) [imdbid-{imdbid}]/Season {season}/{ti
 # ==============================
 
 # Streaming provider to use.
-# Look at SUPPORTED_PROVIDERS in config.py for options.
-ANIWORLD_PROVIDER=VOE
+# Options: Auto | VOE | Vidmoly | Vidoza | Doodstream
+ANIWORLD_PROVIDER=Auto
+
+# Provider priority used when ANIWORLD_PROVIDER=Auto.
+ANIWORLD_PROVIDER_ORDER=VOE,Vidmoly,Vidoza,Doodstream
+
+# Number of Web UI queue items that may download at the same time.
+# Keep this modest because each active item can spawn FFmpeg and browser work.
+ANIWORLD_MAX_PARALLEL_DOWNLOADS=2
 
 # Pick a random anime instead of the one you pass in.
 # 0 = off, 1 = on
@@ -148,8 +155,8 @@ ANIWORLD_SYNC_SCHEDULE=0
 ANIWORLD_SYNC_LANGUAGE=German Dub
 
 # Default provider for new sync jobs.
-# Options: VOE | Vidmoly | Vidoza
-ANIWORLD_SYNC_PROVIDER=VOE
+# Options: Auto | VOE | Vidmoly | Vidoza | Doodstream
+ANIWORLD_SYNC_PROVIDER=Auto
 
 
 # ==============================

--- a/src/aniworld/arguments.py
+++ b/src/aniworld/arguments.py
@@ -8,7 +8,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from .anime4k import anime4k
-from .config import ACTION_METHODS, LANG_LABELS, SUPPORTED_PROVIDERS, VERSION
+from .config import ACTION_METHODS, LANG_LABELS, PROVIDER_CHOICES, VERSION
 from .logger import get_logger
 
 logger = get_logger(__name__)
@@ -138,7 +138,7 @@ def parse_args():
     playback.add_argument(
         "-p",
         "--provider",
-        choices=sorted(SUPPORTED_PROVIDERS),
+        choices=sorted(PROVIDER_CHOICES),
         help="Choose provider",
     )
 

--- a/src/aniworld/config.py
+++ b/src/aniworld/config.py
@@ -113,19 +113,63 @@ logger.debug("Config initialized successfully")
 # -----------------------------
 # Provider Stuff
 # -----------------------------
+AUTO_PROVIDER = "Auto"
+
 SUPPORTED_PROVIDERS = (
     "VOE",
     "Vidmoly",
     "Vidoza",
-    # "Doodstream",
+    "Doodstream",
     # "Filemoon",
     # "LoadX",
     # "Luluvdo",
     # "Streamtape",
 )
 
+PROVIDER_CHOICES = (AUTO_PROVIDER,) + SUPPORTED_PROVIDERS
+
+
+def get_provider_order():
+    """Return the provider order used by automatic provider selection."""
+    raw = os.getenv("ANIWORLD_PROVIDER_ORDER", "").strip()
+    if raw:
+        requested = [p.strip() for p in raw.split(",") if p.strip()]
+    else:
+        requested = list(SUPPORTED_PROVIDERS)
+
+    ordered = []
+    for provider in requested:
+        if provider in SUPPORTED_PROVIDERS and provider not in ordered:
+            ordered.append(provider)
+
+    for provider in SUPPORTED_PROVIDERS:
+        if provider not in ordered:
+            ordered.append(provider)
+
+    return tuple(ordered)
+
+
+def get_max_parallel_downloads():
+    """Return a bounded number of queue workers for the Web UI."""
+    raw = os.getenv("ANIWORLD_MAX_PARALLEL_DOWNLOADS", "2").strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            f"Invalid ANIWORLD_MAX_PARALLEL_DOWNLOADS={raw!r}, falling back to 2"
+        )
+        value = 2
+    return max(1, min(value, 8))
+
+
 PROVIDER_HEADERS_D = {
-    "Vidmoly": {"Referer": "https://vidmoly.biz"},
+    "Vidmoly": {
+        "User-Agent": DEFAULT_USER_AGENT,
+        "Referer": "https://vidmoly.biz/",
+        "Origin": "https://vidmoly.biz",
+        "Accept": "*/*",
+        "Accept-Language": "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
+    },
     "Doodstream": {"Referer": "https://dood.li/"},
     "VOE": {
         "User-Agent": DEFAULT_USER_AGENT,
@@ -147,7 +191,11 @@ PROVIDER_HEADERS_D = {
 }
 
 PROVIDER_HEADERS_W = {
-    "Vidmoly": {"Referer": "https://vidmoly.biz"},
+    "Vidmoly": {
+        "User-Agent": DEFAULT_USER_AGENT,
+        "Referer": "https://vidmoly.biz/",
+        "Origin": "https://vidmoly.biz",
+    },
     "Doodstream": {"Referer": "https://dood.li/"},
     "VOE": {"User-Agent": DEFAULT_USER_AGENT},
     "Luluvdo": {"User-Agent": LULUVDO_USER_AGENT},

--- a/src/aniworld/extractors/provider/doodstream.py
+++ b/src/aniworld/extractors/provider/doodstream.py
@@ -3,15 +3,17 @@ import random
 import re
 import time
 import warnings
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import niquests
 from urllib3.exceptions import InsecureRequestWarning
 
 try:
-    from ...config import DEFAULT_USER_AGENT
+    from ...config import DEFAULT_USER_AGENT, GLOBAL_SESSION
+    from ...playwright.captcha import solve_captcha
 except ImportError:
-    from aniworld.config import DEFAULT_USER_AGENT
+    from aniworld.config import DEFAULT_USER_AGENT, GLOBAL_SESSION
+    from aniworld.playwright.captcha import solve_captcha
 
 warnings.simplefilter("ignore", InsecureRequestWarning)
 
@@ -20,7 +22,7 @@ warnings.simplefilter("ignore", InsecureRequestWarning)
 # -----------------------------
 DOODSTREAM_BASE_URL = "https://dood.li"
 RANDOM_STRING_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-PASS_MD5_PATTERN = r"\$\.get\('([^']*\/pass_md5\/[^']*)'"
+PASS_MD5_PATTERN = r"\$\.get\([\"']([^\"']*\/pass_md5\/[^\"']*)[\"']"
 TOKEN_PATTERN = r"token=([a-zA-Z0-9]+)"
 
 
@@ -32,6 +34,9 @@ def _get_headers(referer=None):
     return {
         "User-Agent": DEFAULT_USER_AGENT,
         "Referer": referer or f"{DOODSTREAM_BASE_URL}/",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Accept-Encoding": "gzip, deflate",
     }
 
 
@@ -51,9 +56,27 @@ def _generate_random_string(length=10):
 def _get_embed_page(embed_url, headers=None):
     """Fetch HTML content of the embed page."""
     headers = headers or _get_headers()
-    resp = niquests.get(embed_url, headers=headers, verify=False)
+    resp = GLOBAL_SESSION.get(embed_url, headers=headers, verify=False)
+    html = resp.text
+    if "Just a moment..." in html and "cloudflare" in html.lower():
+        logging.warning(f"Cloudflare challenge on Doodstream — solving via browser: {resp.url}")
+        solve_captcha(embed_url)
+        resp = GLOBAL_SESSION.get(embed_url, headers=headers, verify=False)
+        html = resp.text
+        if "Just a moment..." in html and "cloudflare" in html.lower():
+            raise ValueError(
+                f"Doodstream Cloudflare challenge unsolvable: {resp.url}"
+            )
     resp.raise_for_status()
-    return resp.text
+    return html
+
+
+def _get_base_url(url):
+    """Return the scheme/netloc base URL for the active Doodstream mirror."""
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return DOODSTREAM_BASE_URL
+    return f"{parsed.scheme}://{parsed.netloc}"
 
 
 def _get_pass_md5_url(embed_html, embed_url):
@@ -62,7 +85,7 @@ def _get_pass_md5_url(embed_html, embed_url):
         PASS_MD5_PATTERN, embed_html, "pass_md5 URL", embed_url
     )
     if not pass_md5_url.startswith("http"):
-        pass_md5_url = urljoin(DOODSTREAM_BASE_URL, pass_md5_url)
+        pass_md5_url = urljoin(_get_base_url(embed_url), pass_md5_url)
     return pass_md5_url
 
 
@@ -80,13 +103,15 @@ def get_direct_link_from_doodstream(embed_url):
         raise ValueError("Embed URL cannot be empty")
 
     logging.info(f"Extracting Doodstream direct link from: {embed_url}")
-    headers = _get_headers(embed_url)
+    base_url = _get_base_url(embed_url)
+    embed_headers = _get_headers(f"{base_url}/")
+    md5_headers = _get_headers(embed_url)
 
-    embed_html = _get_embed_page(embed_url, headers)
+    embed_html = _get_embed_page(embed_url, embed_headers)
     pass_md5_url = _get_pass_md5_url(embed_html, embed_url)
     token = _get_token(embed_html, embed_url)
 
-    md5_resp = niquests.get(pass_md5_url, headers=headers, verify=False)
+    md5_resp = GLOBAL_SESSION.get(pass_md5_url, headers=md5_headers, verify=False)
     md5_resp.raise_for_status()
     video_base_url = md5_resp.text.strip()
     if not video_base_url:

--- a/src/aniworld/extractors/provider/vidmoly.py
+++ b/src/aniworld/extractors/provider/vidmoly.py
@@ -1,9 +1,9 @@
 import re
 
 try:
-    from ...config import GLOBAL_SESSION
+    from ...config import DEFAULT_USER_AGENT, GLOBAL_SESSION
 except ImportError:
-    from aniworld.config import GLOBAL_SESSION
+    from aniworld.config import DEFAULT_USER_AGENT, GLOBAL_SESSION
 
 # -----------------------------
 # Constants
@@ -19,7 +19,14 @@ PREVIEW_IMAGE_PATTERN = re.compile(
 # -----------------------------
 def _get_headers():
     """Return headers for Vidmoly requests."""
-    return {"Referer": "https://vidmoly.biz"}
+    return {
+        "User-Agent": DEFAULT_USER_AGENT,
+        "Referer": "https://vidmoly.biz/",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
+        # Keep niquests away from encodings that this endpoint can misdecode.
+        "Accept-Encoding": "gzip, deflate",
+    }
 
 
 def _extract_regex(pattern, content, name, url):

--- a/src/aniworld/menu.py
+++ b/src/aniworld/menu.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import npyscreen
 
-from .config import INVERSE_LANG_KEY_MAP, LANG_LABELS, VERSION, logger
+from .config import AUTO_PROVIDER, INVERSE_LANG_KEY_MAP, LANG_LABELS, VERSION, logger
 from .providers import resolve_provider
 
 
@@ -54,7 +54,10 @@ def _extract_menu_providers(provider_data: dict) -> list[str]:
         if isinstance(providers_map, dict):
             provider_names.update(str(p) for p in providers_map.keys())
 
-    return sorted(provider_names)
+    providers = sorted(provider_names)
+    if providers:
+        return [AUTO_PROVIDER] + [p for p in providers if p != AUTO_PROVIDER]
+    return providers
 
 
 # ============================================================

--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import threading as _threading
 from typing import Tuple
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import ffmpeg
 
@@ -15,27 +16,37 @@ from ...autodeps import DependencyManager
 
 try:
     from ...autodeps import get_player_path, get_syncplay_path
+    from ...extractors import provider_functions
     from ...config import (
+        AUTO_PROVIDER,
         INVERSE_LANG_LABELS,
         LANG_CODE_MAP,
         LANG_KEY_MAP,
+        GLOBAL_SESSION,
         PROVIDER_HEADERS_D,
         PROVIDER_HEADERS_W,
+        SUPPORTED_PROVIDERS,
         Audio,
         Subtitles,
+        get_provider_order,
         get_video_codec,
         logger,
     )
 except ImportError:
     from aniworld.autodeps import get_player_path, get_syncplay_path
+    from aniworld.extractors import provider_functions
     from aniworld.config import (
+        AUTO_PROVIDER,
         INVERSE_LANG_LABELS,
         LANG_CODE_MAP,
         LANG_KEY_MAP,
+        GLOBAL_SESSION,
         PROVIDER_HEADERS_D,
         PROVIDER_HEADERS_W,
+        SUPPORTED_PROVIDERS,
         Audio,
         Subtitles,
+        get_provider_order,
         get_video_codec,
         logger,
     )
@@ -142,21 +153,218 @@ def _remove_empty_dirs(folder_path, base_folder):
         pass
 
 
-# Thread-safe global for current ffmpeg download progress (used by web UI)
+def _reset_provider_cache(episode):
+    for attr in list(vars(episode)):
+        if attr.endswith("__redirect_url") or attr.endswith("__provider_url"):
+            setattr(episode, attr, None)
+
+
+def _set_selected_provider(episode, provider):
+    """Set the selected provider on episode classes with name-mangled fields."""
+    for attr in list(vars(episode)):
+        if attr.endswith("__selected_provider_param"):
+            setattr(episode, attr, provider)
+        elif attr.endswith("__selected_provider"):
+            setattr(episode, attr, None)
+    _reset_provider_cache(episode)
+
+
+def _language_values(language):
+    try:
+        return tuple(part.value for part in language)
+    except (TypeError, AttributeError):
+        return language
+
+
+def _language_matches(left, right):
+    return left == right or _language_values(left) == _language_values(right)
+
+
+def _language_for_provider_lookup(episode):
+    if hasattr(episode, "_normalize_language"):
+        return episode._normalize_language(episode.selected_language)
+
+    key = INVERSE_LANG_LABELS.get(episode.selected_language)
+    if key is not None:
+        return LANG_KEY_MAP[key]
+
+    return episode.selected_language
+
+
+def _provider_map_for_language(episode):
+    language = _language_for_provider_lookup(episode)
+    provider_data = episode.provider_data
+    data = provider_data._data if hasattr(provider_data, "_data") else provider_data
+
+    for key, providers in data.items():
+        if _language_matches(key, language):
+            return providers or {}
+
+    try:
+        return provider_data.get(language) or {}
+    except AttributeError:
+        return {}
+
+
+def _is_implemented_provider(provider):
+    return f"get_direct_link_from_{provider.lower()}" in provider_functions
+
+
+def _auto_provider_candidates(episode):
+    available = _provider_map_for_language(episode)
+    ordered = get_provider_order()
+
+    candidates = [
+        provider
+        for provider in ordered
+        if provider in available and _is_implemented_provider(provider)
+    ]
+
+    if not candidates:
+        candidates = [
+            provider
+            for provider in available
+            if provider in SUPPORTED_PROVIDERS and _is_implemented_provider(provider)
+        ]
+
+    if not candidates:
+        raise ValueError(
+            f"No implemented providers are available for {episode.selected_language}"
+        )
+
+    return candidates
+
+
+def _provider_candidates_for_download(episode):
+    requested = episode.selected_provider
+    if requested == AUTO_PROVIDER:
+        return _auto_provider_candidates(episode)
+    return [requested]
+
+
+def _cleanup_temp_files(episode):
+    for suffix in (
+        ".temp_full.mkv",
+        ".temp_audio.mkv",
+        ".temp_video.mkv",
+        ".new.mkv",
+        ".vidmoly_master.m3u8",
+    ):
+        temp = episode._episode_path.with_suffix(suffix)
+        if temp.exists():
+            temp.unlink()
+
+    for temp in episode._episode_path.parent.glob(
+        f"{episode._episode_path.stem}.vidmoly_*.m3u8"
+    ):
+        temp.unlink()
+
+
+def _append_query_if_missing(url, query):
+    if not query:
+        return url
+
+    parsed = urlsplit(url)
+    if parsed.query:
+        return url
+
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment)
+    )
+
+
+def _materialize_vidmoly_variant_playlist(playlist_url, playlist_path, headers, query):
+    """Write a local Vidmoly variant playlist with signed segment URLs."""
+    resp = GLOBAL_SESSION.get(playlist_url, headers=headers, timeout=30)
+    resp.raise_for_status()
+    playlist = resp.text
+    if "#EXTM3U" not in playlist[:100]:
+        return playlist_url
+
+    parsed = urlsplit(playlist_url)
+    query = parsed.query or query
+    lines = []
+    for line in playlist.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            lines.append(line)
+            continue
+
+        segment_url = urljoin(playlist_url, stripped)
+        lines.append(_append_query_if_missing(segment_url, query))
+
+    playlist_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return playlist_path.name
+
+
+def _materialize_vidmoly_master_playlist(stream_url, playlist_path, headers):
+    """Write local Vidmoly playlists so FFmpeg keeps signed child/segment URLs."""
+    parsed_master = urlsplit(stream_url)
+    if parsed_master.scheme not in ("http", "https") or ".m3u8" not in parsed_master.path:
+        return stream_url
+
+    resp = GLOBAL_SESSION.get(stream_url, headers=headers, timeout=30)
+    resp.raise_for_status()
+    playlist = resp.text
+    if "#EXTM3U" not in playlist[:100]:
+        return stream_url
+
+    lines = []
+    variant_index = 0
+    for line in playlist.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            lines.append(line)
+            continue
+
+        child_url = urljoin(stream_url, stripped)
+        child_url = _append_query_if_missing(child_url, parsed_master.query)
+
+        if ".m3u8" in urlsplit(child_url).path:
+            variant_path = playlist_path.with_name(
+                f"{playlist_path.stem}_variant_{variant_index}.m3u8"
+            )
+            lines.append(
+                _materialize_vidmoly_variant_playlist(
+                    child_url, variant_path, headers, parsed_master.query
+                )
+            )
+            variant_index += 1
+        else:
+            lines.append(_append_query_if_missing(child_url, parsed_master.query))
+
+    playlist_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(playlist_path)
+
+
+# Thread-safe FFmpeg progress by queue item (used by web UI)
 _ffmpeg_progress_lock = _threading.Lock()
-_ffmpeg_progress = {
-    "percent": 0.0,
-    "time": "",
-    "speed": "",
-    "bandwidth": "",
-    "active": False,
-}
+_ffmpeg_progress = {}
+_ffmpeg_local = _threading.local()
+
+
+def _empty_ffmpeg_progress(active=False):
+    return {"percent": 0.0, "time": "", "speed": "", "bandwidth": "", "active": active}
+
+
+def set_ffmpeg_progress_queue_id(queue_id):
+    """Associate FFmpeg progress in the current thread with a queue item."""
+    _ffmpeg_local.queue_id = queue_id
+
+
+def clear_ffmpeg_progress_queue_id():
+    """Clear queue association for FFmpeg progress in the current thread."""
+    queue_id = getattr(_ffmpeg_local, "queue_id", None)
+    _ffmpeg_local.queue_id = None
+    if queue_id is not None:
+        with _ffmpeg_progress_lock:
+            _ffmpeg_progress[str(queue_id)] = _empty_ffmpeg_progress(active=False)
 
 
 def get_ffmpeg_progress():
-    """Return a snapshot of the current ffmpeg download progress."""
+    """Return a snapshot of FFmpeg progress keyed by queue item id."""
     with _ffmpeg_progress_lock:
-        return dict(_ffmpeg_progress)
+        return {key: dict(value) for key, value in _ffmpeg_progress.items()}
 
 
 def _parse_ffmpeg_time(time_str):
@@ -172,7 +380,7 @@ def _parse_ffmpeg_time(time_str):
 
 def _print_cli_progress(percent, time_str, speed_str, label=""):
     """Print a simple CLI progress bar without ANSI colors."""
-    if not sys.stderr.isatty():
+    if not sys.stderr.isatty() or _threading.current_thread() is not _threading.main_thread():
         return
     bar_width = 30
     filled = int(bar_width * percent / 100)
@@ -199,7 +407,10 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
     )
 
     debug_mode = os.getenv("ANIWORLD_DEBUG_MODE", "0") == "1"
-    is_tty = sys.stderr.isatty()
+    is_tty = (
+        sys.stderr.isatty()
+        and _threading.current_thread() is _threading.main_thread()
+    )
 
     # Regex to extract progress indicators from ffmpeg status lines
     _RE_FRAME = re.compile(r"frame=\s*(\d+)")
@@ -255,11 +466,10 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
     last_size_ts = None
     last_change = time.monotonic()
     total_duration = 0.0
+    progress_key = str(getattr(_ffmpeg_local, "queue_id", None) or "global")
 
     with _ffmpeg_progress_lock:
-        _ffmpeg_progress.update(
-            percent=0.0, time="", speed="", bandwidth="", active=True
-        )
+        _ffmpeg_progress[progress_key] = _empty_ffmpeg_progress(active=True)
 
     try:
         while True:
@@ -326,16 +536,19 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
                     elapsed = _parse_ffmpeg_time(cur_time_str)
                     percent = min((elapsed / total_duration) * 100, 100.0)
 
-                # Update global progress for web UI
+                # Update this queue item's progress for the Web UI.
                 with _ffmpeg_progress_lock:
-                    prev_bw = _ffmpeg_progress.get("bandwidth", "")
-                    _ffmpeg_progress.update(
+                    current_progress = _ffmpeg_progress.get(
+                        progress_key, _empty_ffmpeg_progress(active=True)
+                    )
+                    current_progress.update(
                         percent=round(percent, 1),
                         time=cur_time_str,
                         speed=cur_speed_str,
-                        bandwidth=cur_bw_str or prev_bw,
+                        bandwidth=cur_bw_str or current_progress.get("bandwidth", ""),
                         active=True,
                     )
+                    _ffmpeg_progress[progress_key] = current_progress
 
                 if debug_mode:
                     logger.info(f"[FFmpeg Progress] {line_str}")
@@ -371,9 +584,7 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
 
     finally:
         with _ffmpeg_progress_lock:
-            _ffmpeg_progress.update(
-                percent=0.0, time="", speed="", bandwidth="", active=False
-            )
+            _ffmpeg_progress[progress_key] = _empty_ffmpeg_progress(active=False)
 
     reader_thread.join(timeout=5)
     process.wait()
@@ -387,192 +598,210 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
         raise RuntimeError(f"ffmpeg error (rc={process.returncode}): {detail}")
 
 
+def _download_once_with_current_provider(self):
+    check = check_downloaded(self._episode_path)
+
+    headers = PROVIDER_HEADERS_D.get(self.selected_provider, {})
+    input_kwargs = {
+        "reconnect": 1,
+        "reconnect_streamed": 1,
+        "reconnect_delay_max": 300,  # wait up to 5 min for connection recovery
+    }
+    if headers:
+        header_list = [f"{k}: {v}" for k, v in headers.items()]
+        input_kwargs["headers"] = "\r\n".join(header_list) + "\r\n"
+
+    url = (getattr(self, "url", "") or "").lower()
+    is_serienstream = ("serienstream.to" in url) or ("s.to" in url)
+
+    if is_serienstream and hasattr(self, "_normalize_language"):
+        audio_enum, sub_enum = self._normalize_language(self.selected_language)
+        audio_code = {"German": "deu", "English": "eng"}.get(
+            getattr(audio_enum, "value", None)
+        )
+        if not audio_code:
+            raise ValueError(f"Unsupported audio language for serienstream.to: {audio_enum}")
+        wants_clean_video = True
+        sub_video_code = None
+    else:
+        selected_key = INVERSE_LANG_LABELS[self.selected_language]
+        audio_enum, sub_enum = LANG_KEY_MAP[selected_key]
+
+        audio_code = LANG_CODE_MAP[audio_enum]
+        wants_clean_video = sub_enum == Subtitles.NONE
+        sub_video_code = None if wants_clean_video else LANG_CODE_MAP[sub_enum]
+
+    has_video = bool(check["video_langs"])
+    has_audio = audio_code in check["audio_langs"]
+
+    need_audio = not has_audio
+    if not has_video:
+        need_video = True
+    elif not wants_clean_video:
+        need_video = sub_video_code not in check["video_langs"]
+    else:
+        need_video = False
+
+    if not need_audio and not need_video:
+        logger.debug(f"[SKIPPED] {self._file_name}")
+        return
+
+    os.makedirs(self._folder_path, exist_ok=True)
+
+    stream_url = self.stream_url
+    if self.selected_provider == "Vidmoly":
+        stream_url = _materialize_vidmoly_master_playlist(
+            stream_url,
+            self._episode_path.with_suffix(".vidmoly_master.m3u8"),
+            headers,
+        )
+        if stream_url.endswith(".vidmoly_master.m3u8"):
+            for option in (
+                "headers",
+                "reconnect",
+                "reconnect_streamed",
+                "reconnect_delay_max",
+            ):
+                input_kwargs.pop(option, None)
+            input_kwargs["protocol_whitelist"] = "file,http,https,tcp,tls,crypto,data"
+
+    # Label for CLI progress bar (e.g. "Title S01E001")
+    ep_label = os.path.splitext(self._file_name)[0] if self._file_name else ""
+
+    full_stream_needed = need_audio and need_video
+
+    temp_audio = self._episode_path.with_suffix(".temp_audio.mkv")
+    temp_video = self._episode_path.with_suffix(".temp_video.mkv")
+    temp_full = self._episode_path.with_suffix(".temp_full.mkv")
+
+    if full_stream_needed:
+        logger.debug(
+            f"[DOWNLOADING] full preset with {self.selected_provider} "
+            "(audio + video together)"
+        )
+
+        stream_metadata = {"metadata:s:a:0": f"language={audio_code}"}
+        if (not wants_clean_video) and sub_video_code:
+            stream_metadata["metadata:s:v:0"] = f"language={sub_video_code}"
+
+        video_codec = get_video_codec()
+        _run_ffmpeg_with_progress(
+            ffmpeg.input(stream_url, **input_kwargs).output(
+                str(temp_full),
+                vcodec=video_codec,
+                acodec=video_codec,
+                **stream_metadata,
+            ),
+            label=ep_label,
+        )
+
+        if self._episode_path.exists():
+            inputs = [
+                ffmpeg.input(str(self._episode_path)),
+                ffmpeg.input(str(temp_full)),
+            ]
+            output_path = self._episode_path.with_suffix(".new.mkv")
+            _run_ffmpeg_with_progress(ffmpeg.output(*inputs, str(output_path), c="copy"))
+            os.replace(output_path, self._episode_path)
+        else:
+            os.replace(temp_full, self._episode_path)
+
+        if temp_full.exists():
+            temp_full.unlink()
+        _cleanup_temp_files(self)
+        return
+
+    if need_audio:
+        logger.debug(f"[DOWNLOADING] audio stream with {self.selected_provider}")
+        video_codec = get_video_codec()
+        _run_ffmpeg_with_progress(
+            ffmpeg.input(stream_url, **input_kwargs).output(
+                str(temp_audio),
+                acodec=video_codec,
+                map="0:a:0?",
+                **{"metadata:s:a:0": f"language={audio_code}"},
+            ),
+            label=ep_label,
+        )
+
+    if need_video:
+        logger.debug(f"[DOWNLOADING] video stream with {self.selected_provider}")
+        video_codec = get_video_codec()
+        _run_ffmpeg_with_progress(
+            ffmpeg.input(stream_url, **input_kwargs).output(
+                str(temp_video),
+                vcodec=video_codec,
+                map="0:v:0?",
+                **(
+                    {}
+                    if wants_clean_video
+                    else {"metadata:s:v:0": f"language={sub_video_code}"}
+                ),
+            ),
+            label=ep_label,
+        )
+
+    logger.debug("[MUXING] combining streams")
+    inputs = (
+        [ffmpeg.input(str(self._episode_path))]
+        if self._episode_path.exists()
+        else []
+    )
+
+    if need_audio:
+        inputs.append(ffmpeg.input(str(temp_audio)))
+    if need_video:
+        inputs.append(ffmpeg.input(str(temp_video)))
+
+    output_path = self._episode_path.with_suffix(".new.mkv")
+    _run_ffmpeg_with_progress(ffmpeg.output(*inputs, str(output_path), c="copy"))
+    os.replace(output_path, self._episode_path)
+
+    _cleanup_temp_files(self)
+
+
 def download(self):
-    """Download required audio/video streams for an episode (AniWorld + s.to) with retry logic."""
+    """Download required audio/video streams with retry and optional provider fallback."""
     if platform.system() == "Windows":
         manager = DependencyManager()
         manager.fetch_binary("ffmpeg")
 
+    requested_provider = self.selected_provider
+    auto_provider = requested_provider == AUTO_PROVIDER
+    provider_candidates = _provider_candidates_for_download(self)
     max_retries = 3
-    attempt = 0
+    last_error = None
 
-    while attempt < max_retries:
-        try:
-            attempt += 1
-            check = check_downloaded(self._episode_path)
+    for provider in provider_candidates:
+        _set_selected_provider(self, provider)
+        if auto_provider:
+            logger.info(f"[AUTO PROVIDER] Trying {provider}")
 
-            headers = PROVIDER_HEADERS_D.get(self.selected_provider, {})
-            input_kwargs = {
-                "reconnect": 1,
-                "reconnect_streamed": 1,
-                "reconnect_delay_max": 300,  # wait up to 5 min for connection recovery
-            }
-            if headers:
-                header_list = [f"{k}: {v}" for k, v in headers.items()]
-                input_kwargs["headers"] = "\r\n".join(header_list) + "\r\n"
-
-            url = (getattr(self, "url", "") or "").lower()
-            is_serienstream = ("serienstream.to" in url) or ("s.to" in url)
-
-            if is_serienstream and hasattr(self, "_normalize_language"):
-                audio_enum, sub_enum = self._normalize_language(self.selected_language)
-                audio_code = {"German": "deu", "English": "eng"}.get(
-                    getattr(audio_enum, "value", None)
-                )
-                if not audio_code:
-                    raise ValueError(
-                        f"Unsupported audio language for serienstream.to: {audio_enum}"
-                    )
-                wants_clean_video = True
-                sub_video_code = None
-            else:
-                selected_key = INVERSE_LANG_LABELS[self.selected_language]
-                audio_enum, sub_enum = LANG_KEY_MAP[selected_key]
-
-                audio_code = LANG_CODE_MAP[audio_enum]
-                wants_clean_video = sub_enum == Subtitles.NONE
-                sub_video_code = None if wants_clean_video else LANG_CODE_MAP[sub_enum]
-
-            has_video = bool(check["video_langs"])
-            has_audio = audio_code in check["audio_langs"]
-
-            need_audio = not has_audio
-            if not has_video:
-                need_video = True
-            elif not wants_clean_video:
-                need_video = sub_video_code not in check["video_langs"]
-            else:
-                need_video = False
-
-            if not need_audio and not need_video:
-                logger.debug(f"[SKIPPED] {self._file_name}")
+        for attempt in range(1, max_retries + 1):
+            try:
+                _download_once_with_current_provider(self)
+                if auto_provider:
+                    logger.info(f"[AUTO PROVIDER] Using {provider}")
                 return
-
-            os.makedirs(self._folder_path, exist_ok=True)
-
-            # Label for CLI progress bar (e.g. "Title S01E001")
-            ep_label = os.path.splitext(self._file_name)[0] if self._file_name else ""
-
-            full_stream_needed = need_audio and need_video
-
-            temp_audio = self._episode_path.with_suffix(".temp_audio.mkv")
-            temp_video = self._episode_path.with_suffix(".temp_video.mkv")
-            temp_full = self._episode_path.with_suffix(".temp_full.mkv")
-
-            if full_stream_needed:
-                logger.debug("[DOWNLOADING] full preset (audio + video together)")
-
-                stream_metadata = {"metadata:s:a:0": f"language={audio_code}"}
-                if (not wants_clean_video) and sub_video_code:
-                    stream_metadata["metadata:s:v:0"] = f"language={sub_video_code}"
-
-                video_codec = get_video_codec()
-                _run_ffmpeg_with_progress(
-                    ffmpeg.input(self.stream_url, **input_kwargs).output(
-                        str(temp_full),
-                        vcodec=video_codec,
-                        acodec=video_codec,
-                        **stream_metadata,
-                    ),
-                    label=ep_label,
+            except Exception as e:
+                last_error = e
+                _cleanup_temp_files(self)
+                logger.error(
+                    f"Download attempt {attempt}/{max_retries} with "
+                    f"{self.selected_provider} failed: {e}"
                 )
-
-                if self._episode_path.exists():
-                    inputs = [
-                        ffmpeg.input(str(self._episode_path)),
-                        ffmpeg.input(str(temp_full)),
-                    ]
-                    output_path = self._episode_path.with_suffix(".new.mkv")
-                    _run_ffmpeg_with_progress(
-                        ffmpeg.output(*inputs, str(output_path), c="copy")
-                    )
-                    os.replace(output_path, self._episode_path)
-                else:
-                    os.replace(temp_full, self._episode_path)
-
-                if temp_full.exists():
-                    temp_full.unlink()
-                return
-
-            if need_audio:
-                logger.debug("[DOWNLOADING] audio stream")
-                video_codec = get_video_codec()
-                _run_ffmpeg_with_progress(
-                    ffmpeg.input(self.stream_url, **input_kwargs).output(
-                        str(temp_audio),
-                        acodec=video_codec,
-                        map="0:a:0?",
-                        **{"metadata:s:a:0": f"language={audio_code}"},
-                    ),
-                    label=ep_label,
-                )
-
-            if need_video:
-                logger.debug("[DOWNLOADING] video stream")
-                video_codec = get_video_codec()
-                _run_ffmpeg_with_progress(
-                    ffmpeg.input(self.stream_url, **input_kwargs).output(
-                        str(temp_video),
-                        vcodec=video_codec,
-                        map="0:v:0?",
-                        **(
-                            {}
-                            if wants_clean_video
-                            else {"metadata:s:v:0": f"language={sub_video_code}"}
-                        ),
-                    ),
-                    label=ep_label,
-                )
-
-            logger.debug("[MUXING] combining streams")
-            inputs = (
-                [ffmpeg.input(str(self._episode_path))]
-                if self._episode_path.exists()
-                else []
-            )
-
-            if need_audio:
-                inputs.append(ffmpeg.input(str(temp_audio)))
-            if need_video:
-                inputs.append(ffmpeg.input(str(temp_video)))
-
-            output_path = self._episode_path.with_suffix(".new.mkv")
-            _run_ffmpeg_with_progress(
-                ffmpeg.output(*inputs, str(output_path), c="copy")
-            )
-            os.replace(output_path, self._episode_path)
-
-            for f in (temp_audio, temp_video):
-                if f.exists():
-                    f.unlink()
-
-            # If download succeeds, exit loop
-            break
-
-        except Exception as e:
-            # Clean up temp files from failed attempt
-            for suffix in (
-                ".temp_full.mkv",
-                ".temp_audio.mkv",
-                ".temp_video.mkv",
-                ".new.mkv",
-            ):
-                temp = self._episode_path.with_suffix(suffix)
-                if temp.exists():
-                    temp.unlink()
-
-            logger.error(f"Download attempt {attempt}/{max_retries} failed: {e}")
-            if attempt >= max_retries:
-                _remove_empty_dirs(self._folder_path, self._base_folder)
-                raise
-            else:
-                # Reset cached URL properties so retry resolves fresh URLs
-                for attr in list(vars(self)):
-                    if attr.endswith("__redirect_url") or attr.endswith(
-                        "__provider_url"
-                    ):
-                        setattr(self, attr, None)
+                if attempt >= max_retries:
+                    break
+                _reset_provider_cache(self)
                 logger.debug("Retrying download...")
+
+        if auto_provider:
+            logger.warning(f"[AUTO PROVIDER] {provider} failed, trying next provider")
+
+    _remove_empty_dirs(self._folder_path, self._base_folder)
+    if last_error:
+        raise last_error
+    raise RuntimeError("Download failed: no provider candidates available")
 
 
 def watch(self):

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import threading
 import time
@@ -7,9 +8,19 @@ import requests
 from flask import Flask, jsonify, redirect, render_template, request, url_for
 from flask_wtf.csrf import CSRFProtect
 
-from ..config import LANG_KEY_MAP, LANG_LABELS, SUPPORTED_PROVIDERS
+from ..config import (
+    AUTO_PROVIDER,
+    LANG_KEY_MAP,
+    LANG_LABELS,
+    SUPPORTED_PROVIDERS,
+    get_max_parallel_downloads,
+)
 from ..extractors import provider_functions
 from ..logger import get_logger
+from ..models.common.common import (
+    clear_ffmpeg_progress_queue_id,
+    set_ffmpeg_progress_queue_id,
+)
 from ..providers import resolve_provider
 from ..search import (
     fetch_new_animes,
@@ -75,6 +86,7 @@ def _get_working_providers():
 
 
 WORKING_PROVIDERS = _get_working_providers()
+PROVIDER_OPTIONS = (AUTO_PROVIDER,) + WORKING_PROVIDERS
 
 # Only match series-level links: /anime/stream/<slug> (no season/episode)
 _SERIES_LINK_PATTERN = re.compile(r"^/anime/stream/[a-zA-Z0-9\-]+/?$", re.IGNORECASE)
@@ -135,20 +147,26 @@ def _fetch_public_ip():
     raise RuntimeError(last_error or "Failed to resolve public IP")
 
 
-def _queue_worker():
-    """Single global worker that processes one download at a time."""
+def _queue_worker(worker_id=1):
+    """Process queued downloads. Multiple workers may run in parallel."""
     while True:
         try:
             item = None
             with _queue_lock:
-                if not get_running():
-                    item = get_next_queued()
-                    if item:
-                        set_queue_status(item["id"], "running")
+                item = get_next_queued()
+                if item:
+                    set_queue_status(item["id"], "running")
 
             if not item:
                 time.sleep(3)
                 continue
+
+            logger.info(
+                "Queue worker %s started item %s (%s)",
+                worker_id,
+                item["id"],
+                item["title"],
+            )
 
             episodes = json.loads(item["episodes"])
             errors = []
@@ -214,12 +232,15 @@ def _queue_worker():
                         ep_kwargs["selected_path"] = selected_path
                     episode = prov.episode_cls(**ep_kwargs)
                     _captcha_mod._local.queue_id = item["id"]
+                    set_ffmpeg_progress_queue_id(item["id"])
                     try:
                         episode.download()
                     finally:
                         _captcha_mod._local.queue_id = None
+                        clear_ffmpeg_progress_queue_id()
                 except Exception as e:
                     _captcha_mod._local.queue_id = None
+                    clear_ffmpeg_progress_queue_id()
                     logger.error(f"Download failed for {ep_url}: {e}")
                     errors.append({"url": ep_url, "error": str(e)})
                     update_queue_errors(item["id"], json.dumps(errors))
@@ -244,7 +265,7 @@ def _queue_worker():
 
 
 def _ensure_queue_worker():
-    """Start the queue worker thread once."""
+    """Start queue worker threads once."""
     global _queue_worker_started
     if _queue_worker_started:
         return
@@ -262,8 +283,16 @@ def _ensure_queue_worker():
     finally:
         conn.close()
 
-    thread = threading.Thread(target=_queue_worker, daemon=True)
-    thread.start()
+    worker_count = get_max_parallel_downloads()
+    for worker_id in range(1, worker_count + 1):
+        thread = threading.Thread(
+            target=_queue_worker,
+            args=(worker_id,),
+            daemon=True,
+            name=f"aniworld-queue-{worker_id}",
+        )
+        thread.start()
+    logger.info("Started %d queue worker(s)", worker_count)
 
 
 def _run_autosync_for_job(job):
@@ -640,7 +669,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             "index.html",
             lang_labels=LANG_LABELS,
             sto_lang_labels=sto_lang_labels,
-            supported_providers=WORKING_PROVIDERS,
+            supported_providers=PROVIDER_OPTIONS,
             default_web_language=default_web_language,
         )
 
@@ -877,7 +906,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                         continue
                     working = [p for p in providers.keys() if p in WORKING_PROVIDERS]
                     if working:
-                        provider_info[label] = working
+                        provider_info[label] = [AUTO_PROVIDER] + working
             else:
                 # s.to: plain dict with (Audio, Subtitles) enum tuple keys
                 sto_label_map = {
@@ -890,7 +919,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                         continue
                     working = [p for p in providers.keys() if p in WORKING_PROVIDERS]
                     if working:
-                        provider_info[label] = working
+                        provider_info[label] = [AUTO_PROVIDER] + working
 
             return jsonify({"providers": provider_info})
         except Exception as e:
@@ -944,6 +973,17 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
 
         items = get_queue()
         ffmpeg_pct = get_ffmpeg_progress()
+        for item in items:
+            item["ffmpeg_progress"] = ffmpeg_pct.get(
+                str(item["id"]),
+                {
+                    "percent": 0.0,
+                    "time": "",
+                    "speed": "",
+                    "bandwidth": "",
+                    "active": False,
+                },
+            )
         return jsonify({"items": items, "ffmpeg_progress": ffmpeg_pct})
 
     @app.route("/api/queue/<int:queue_id>", methods=["DELETE"])
@@ -1154,7 +1194,8 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
         disable_english_sub = os.environ.get("ANIWORLD_DISABLE_ENGLISH_SUB", "0")
         sync_schedule = os.environ.get("ANIWORLD_SYNC_SCHEDULE", "0")
         sync_language = os.environ.get("ANIWORLD_SYNC_LANGUAGE", "German Dub")
-        sync_provider = os.environ.get("ANIWORLD_SYNC_PROVIDER", "VOE")
+        sync_provider = os.environ.get("ANIWORLD_SYNC_PROVIDER", AUTO_PROVIDER)
+        max_parallel_downloads = str(get_max_parallel_downloads())
         return jsonify(
             {
                 "download_path": resolved,
@@ -1163,6 +1204,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                 "sync_schedule": sync_schedule,
                 "sync_language": sync_language,
                 "sync_provider": sync_provider,
+                "max_parallel_downloads": max_parallel_downloads,
             }
         )
 
@@ -1201,9 +1243,13 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             os.environ["ANIWORLD_SYNC_LANGUAGE"] = lang
         if "sync_provider" in data:
             prov = str(data["sync_provider"])
-            if prov not in WORKING_PROVIDERS:
+            if prov not in PROVIDER_OPTIONS:
                 return jsonify({"error": f"Invalid sync_provider: {prov}"}), 400
             os.environ["ANIWORLD_SYNC_PROVIDER"] = prov
+        if "max_parallel_downloads" in data:
+            os.environ["ANIWORLD_MAX_PARALLEL_DOWNLOADS"] = str(
+                data["max_parallel_downloads"]
+            )
         return jsonify({"ok": True})
 
     @app.route("/api/custom-paths")

--- a/src/aniworld/web/static/app.js
+++ b/src/aniworld/web/static/app.js
@@ -684,6 +684,12 @@ function updateProviderDropdown() {
 
 function selectDefaultProvider() {
   for (const opt of providerSelect.options) {
+    if (opt.value === "Auto") {
+      providerSelect.value = "Auto";
+      return;
+    }
+  }
+  for (const opt of providerSelect.options) {
     if (opt.value === "VOE") {
       providerSelect.value = "VOE";
       return;
@@ -891,7 +897,7 @@ async function startDownloadAllLangs() {
   try {
     for (const [lang, providers] of Object.entries(availableProviders)) {
       if (!providers.length) continue;
-      const provider = providers.includes("VOE") ? "VOE" : providers[0];
+      const provider = providers.includes("Auto") ? "Auto" : providers[0];
       const dlBody = {
         episodes,
         language: lang,

--- a/src/aniworld/web/static/autosync.js
+++ b/src/aniworld/web/static/autosync.js
@@ -254,7 +254,7 @@ async function openEditModal(id) {
     });
     langSelect.value = job.language || "German Dub";
 
-    document.getElementById("editProvider").value = job.provider || "VOE";
+    document.getElementById("editProvider").value = job.provider || "Auto";
     document.getElementById("editEnabled").value = job.enabled ? "1" : "0";
 
     // Populate path dropdown

--- a/src/aniworld/web/static/queue.js
+++ b/src/aniworld/web/static/queue.js
@@ -32,6 +32,20 @@ function closeQueueModal() {
 
 let lastFfmpegProgress = {};
 
+function getItemFfmpegProgress(item) {
+  if (!item) return {};
+  if (item.ffmpeg_progress) return item.ffmpeg_progress;
+  if (!lastFfmpegProgress) return {};
+
+  const byId = lastFfmpegProgress[String(item.id)];
+  if (byId) return byId;
+
+  // Compatibility with older API shape while the page is still cached.
+  if (lastFfmpegProgress.active !== undefined) return lastFfmpegProgress;
+
+  return {};
+}
+
 function formatBandwidth(bwStr) {
   if (!bwStr) return "";
   const trimmed = String(bwStr).trim();
@@ -104,6 +118,7 @@ function renderQueue(items) {
 
   let html = "";
   visible.forEach((item) => {
+    const ffmpegProgress = getItemFfmpegProgress(item);
     const isRunning = item.status === "running";
     const isActive =
       isRunning || (item.status === "cancelled" && item.current_url);
@@ -146,8 +161,8 @@ function renderQueue(items) {
 
       // Combine episode progress with in-episode ffmpeg progress
       let ffPct = 0;
-      if (isRunning && lastFfmpegProgress.active && item.total_episodes > 0) {
-        ffPct = (lastFfmpegProgress.percent || 0) / item.total_episodes;
+      if (isRunning && ffmpegProgress.active && item.total_episodes > 0) {
+        ffPct = (ffmpegProgress.percent || 0) / item.total_episodes;
       }
       const combinedPct = Math.min(Math.round(epPct + ffPct), 100);
 
@@ -167,11 +182,11 @@ function renderQueue(items) {
       } else {
         let epDetail = item.current_episode + "/" + item.total_episodes + " episodes";
         if (seInfo) epDetail += " - " + seInfo;
-        if (lastFfmpegProgress.active && lastFfmpegProgress.percent > 0) {
-          const bw = formatBandwidth(lastFfmpegProgress.bandwidth || "");
+        if (ffmpegProgress.active && ffmpegProgress.percent > 0) {
+          const bw = formatBandwidth(ffmpegProgress.bandwidth || "");
           epDetail +=
             " (" +
-            lastFfmpegProgress.percent +
+            ffmpegProgress.percent +
             "%" +
             (bw ? " @ " + bw : "") +
             ")";

--- a/src/aniworld/web/templates/autosync.html
+++ b/src/aniworld/web/templates/autosync.html
@@ -47,9 +47,11 @@ endblock %} {% block content %}
         >Provider</label
       >
       <select id="editProvider" class="sync-select">
+        <option>Auto</option>
         <option>VOE</option>
         <option>Vidmoly</option>
         <option>Vidoza</option>
+        <option>Doodstream</option>
       </select>
     </div>
     <div class="settings-row" style="margin-bottom: 12px">

--- a/src/aniworld/web/templates/base.html
+++ b/src/aniworld/web/templates/base.html
@@ -83,7 +83,7 @@
     </div>
 
     <div class="toast" id="toast"></div>
-    <script src="{{ url_for('static', filename='queue.js') }}"></script>
+    <script src="{{ url_for('static', filename='queue.js', v='queue-progress-v2') }}"></script>
 
     <div
       class="captcha-overlay"

--- a/src/aniworld/web/templates/settings.html
+++ b/src/aniworld/web/templates/settings.html
@@ -127,9 +127,11 @@ endblock %} {% block content %}
           onchange="saveSyncDefaults()"
           class="sync-select"
         >
+          <option>Auto</option>
           <option>VOE</option>
           <option>Vidmoly</option>
           <option>Vidoza</option>
+          <option>Doodstream</option>
         </select>
       </div>
     </div>


### PR DESCRIPTION
## Summary

This PR contains a set of proposed bug fixes and improvements for the downloader, mostly focused on provider reliability and WebUI queue behavior.

The changes are meant as ideas/contributions and can be adjusted or split up if preferred.

## Changes

- Add an `Auto` provider option that can try multiple available providers in order.
- Add configurable parallel WebUI queue workers via `ANIWORLD_MAX_PARALLEL_DOWNLOADS`.
- Fix Vidmoly extraction by using more complete request headers.
- Improve Vidmoly HLS handling by preserving signed playlist and segment URLs.
- Enable Doodstream as a selectable provider.
- Improve Doodstream support for mirror domains such as `playmogo.com`.
- Add handling for Doodstream/Cloudflare-protected mirror pages.
- Fix WebUI queue progress so parallel downloads do not share the same FFmpeg progress display.
- Reduce console progress flickering when multiple downloads run at the same time.
- Add `Auto` and Doodstream to relevant WebUI/settings/provider dropdowns.

## Doodstream / Cloudflare

This PR includes changes that allow Doodstream mirror pages protected by Cloudflare to be handled more reliably. This makes Doodstream usable again in cases where the provider redirects through mirror domains.

## Vidmoly

Vidmoly required special handling because some signed HLS URLs lose their token when FFmpeg follows nested playlists. This PR materializes local playlist files so signed child playlists and segments keep the required query parameters.

## Motivation

These changes were tested while using the WebUI with multiple queued downloads. The goal is to make provider selection more resilient, improve parallel queue behavior, and avoid cases where one broken provider blocks the whole download.

Appreciate the work that went into building this.
This repo rly saved my day, thank you guys <3