### PR TITLE
Improve queue progress handling

### DIFF
--- a/src/aniworld/.env.example
+++ b/src/aniworld/.env.example
@@ -50,6 +50,10 @@ ANIWORLD_PROVIDER=VOE
 # The selected provider is always tried first, then the remaining providers follow this order.
 ANIWORLD_PROVIDER_FALLBACK_ORDER=VOE,Vidmoly,Vidoza
 
+# Number of Web UI queue items that may download at the same time.
+# Keep this modest because each active item can spawn FFmpeg and browser work.
+ANIWORLD_MAX_PARALLEL_DOWNLOADS=2
+
 # Pick a random anime instead of the one you pass in.
 # 0 = off, 1 = on
 ANIWORLD_RANDOM_ANIME=0

--- a/src/aniworld/config.py
+++ b/src/aniworld/config.py
@@ -97,6 +97,19 @@ def get_video_codec():
     return VIDEO_CODEC_MAP[codec]
 
 
+def get_max_parallel_downloads():
+    """Return a bounded number of Web UI queue workers."""
+    raw = os.getenv("ANIWORLD_MAX_PARALLEL_DOWNLOADS", "2").strip()
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            f"Invalid ANIWORLD_MAX_PARALLEL_DOWNLOADS={raw!r}, falling back to 2"
+        )
+        value = 2
+    return max(1, min(value, 8))
+
+
 # NIQUESTS
 
 try:

--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -254,21 +254,34 @@ def _resolve_stream_url_with_fallback(self, action_name):
     raise RuntimeError(f"{action_name} failed: no providers available")
 
 
-# Thread-safe global for current ffmpeg download progress (used by web UI)
+# Thread-safe FFmpeg progress by queue item (used by web UI)
 _ffmpeg_progress_lock = _threading.Lock()
-_ffmpeg_progress = {
-    "percent": 0.0,
-    "time": "",
-    "speed": "",
-    "bandwidth": "",
-    "active": False,
-}
+_ffmpeg_progress = {}
+_ffmpeg_local = _threading.local()
+
+
+def _empty_ffmpeg_progress(active=False):
+    return {"percent": 0.0, "time": "", "speed": "", "bandwidth": "", "active": active}
+
+
+def set_ffmpeg_progress_queue_id(queue_id):
+    """Associate FFmpeg progress in the current thread with a queue item."""
+    _ffmpeg_local.queue_id = queue_id
+
+
+def clear_ffmpeg_progress_queue_id():
+    """Clear queue association for FFmpeg progress in the current thread."""
+    queue_id = getattr(_ffmpeg_local, "queue_id", None)
+    _ffmpeg_local.queue_id = None
+    if queue_id is not None:
+        with _ffmpeg_progress_lock:
+            _ffmpeg_progress[str(queue_id)] = _empty_ffmpeg_progress(active=False)
 
 
 def get_ffmpeg_progress():
-    """Return a snapshot of the current ffmpeg download progress."""
+    """Return a snapshot of FFmpeg progress keyed by queue item id."""
     with _ffmpeg_progress_lock:
-        return dict(_ffmpeg_progress)
+        return {key: dict(value) for key, value in _ffmpeg_progress.items()}
 
 
 def _parse_ffmpeg_time(time_str):
@@ -284,7 +297,10 @@ def _parse_ffmpeg_time(time_str):
 
 def _print_cli_progress(percent, time_str, speed_str, label=""):
     """Print a simple CLI progress bar without ANSI colors."""
-    if not sys.stderr.isatty():
+    if (
+        not sys.stderr.isatty()
+        or _threading.current_thread() is not _threading.main_thread()
+    ):
         return
     bar_width = 30
     filled = int(bar_width * percent / 100)
@@ -311,7 +327,10 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
     )
 
     debug_mode = os.getenv("ANIWORLD_DEBUG_MODE", "0") == "1"
-    is_tty = sys.stderr.isatty()
+    is_tty = (
+        sys.stderr.isatty()
+        and _threading.current_thread() is _threading.main_thread()
+    )
 
     # Regex to extract progress indicators from ffmpeg status lines
     _RE_FRAME = re.compile(r"frame=\s*(\d+)")
@@ -367,11 +386,10 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
     last_size_ts = None
     last_change = time.monotonic()
     total_duration = 0.0
+    progress_key = str(getattr(_ffmpeg_local, "queue_id", None) or "global")
 
     with _ffmpeg_progress_lock:
-        _ffmpeg_progress.update(
-            percent=0.0, time="", speed="", bandwidth="", active=True
-        )
+        _ffmpeg_progress[progress_key] = _empty_ffmpeg_progress(active=True)
 
     try:
         while True:
@@ -438,16 +456,19 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
                     elapsed = _parse_ffmpeg_time(cur_time_str)
                     percent = min((elapsed / total_duration) * 100, 100.0)
 
-                # Update global progress for web UI
+                # Update this queue item's progress for the Web UI.
                 with _ffmpeg_progress_lock:
-                    prev_bw = _ffmpeg_progress.get("bandwidth", "")
-                    _ffmpeg_progress.update(
+                    current_progress = _ffmpeg_progress.get(
+                        progress_key, _empty_ffmpeg_progress(active=True)
+                    )
+                    current_progress.update(
                         percent=round(percent, 1),
                         time=cur_time_str,
                         speed=cur_speed_str,
-                        bandwidth=cur_bw_str or prev_bw,
+                        bandwidth=cur_bw_str or current_progress.get("bandwidth", ""),
                         active=True,
                     )
+                    _ffmpeg_progress[progress_key] = current_progress
 
                 if debug_mode:
                     logger.info(f"[FFmpeg Progress] {line_str}")
@@ -483,9 +504,7 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
 
     finally:
         with _ffmpeg_progress_lock:
-            _ffmpeg_progress.update(
-                percent=0.0, time="", speed="", bandwidth="", active=False
-            )
+            _ffmpeg_progress[progress_key] = _empty_ffmpeg_progress(active=False)
 
     reader_thread.join(timeout=5)
     process.wait()

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -12,11 +12,16 @@ from ..config import (
     LANG_KEY_MAP,
     LANG_LABELS,
     SUPPORTED_PROVIDERS,
+    get_max_parallel_downloads,
     get_provider_fallback_order,
     parse_provider_order,
 )
 from ..extractors import provider_functions
 from ..logger import get_logger
+from ..models.common.common import (
+    clear_ffmpeg_progress_queue_id,
+    set_ffmpeg_progress_queue_id,
+)
 from ..providers import resolve_provider
 from ..search import (
     fetch_new_animes,
@@ -43,7 +48,6 @@ from .db import (
     get_next_queued,
     get_queue,
     get_queue_stats,
-    get_running,
     get_sync_stats,
     init_autosync_db,
     init_custom_paths_db,
@@ -192,20 +196,26 @@ def _fetch_public_ip():
     raise RuntimeError(last_error or "Failed to resolve public IP")
 
 
-def _queue_worker():
-    """Single global worker that processes one download at a time."""
+def _queue_worker(worker_id=1):
+    """Process queued downloads. Multiple workers may run in parallel."""
     while True:
         try:
             item = None
             with _queue_lock:
-                if not get_running():
-                    item = get_next_queued()
-                    if item:
-                        set_queue_status(item["id"], "running")
+                item = get_next_queued()
+                if item:
+                    set_queue_status(item["id"], "running")
 
             if not item:
                 time.sleep(3)
                 continue
+
+            logger.info(
+                "Queue worker %s started item %s (%s)",
+                worker_id,
+                item["id"],
+                item["title"],
+            )
 
             episodes = json.loads(item["episodes"])
             errors = []
@@ -271,11 +281,14 @@ def _queue_worker():
                         ep_kwargs["selected_path"] = selected_path
                     episode = prov.episode_cls(**ep_kwargs)
                     _captcha_mod._local.queue_id = item["id"]
+                    set_ffmpeg_progress_queue_id(item["id"])
                     try:
                         episode.download()
                     finally:
+                        clear_ffmpeg_progress_queue_id()
                         _captcha_mod._local.queue_id = None
                 except Exception as e:
+                    clear_ffmpeg_progress_queue_id()
                     _captcha_mod._local.queue_id = None
                     logger.error(f"Download failed for {ep_url}: {e}")
                     errors.append({"url": ep_url, "error": str(e)})
@@ -301,7 +314,7 @@ def _queue_worker():
 
 
 def _ensure_queue_worker():
-    """Start the queue worker thread once."""
+    """Start queue worker threads once."""
     global _queue_worker_started
     if _queue_worker_started:
         return
@@ -319,8 +332,16 @@ def _ensure_queue_worker():
     finally:
         conn.close()
 
-    thread = threading.Thread(target=_queue_worker, daemon=True)
-    thread.start()
+    worker_count = get_max_parallel_downloads()
+    for worker_id in range(1, worker_count + 1):
+        thread = threading.Thread(
+            target=_queue_worker,
+            args=(worker_id,),
+            daemon=True,
+            name=f"aniworld-queue-{worker_id}",
+        )
+        thread.start()
+    logger.info("Started %d queue worker(s)", worker_count)
 
 
 def _run_autosync_for_job(job):
@@ -1009,6 +1030,17 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
 
         items = get_queue()
         ffmpeg_pct = get_ffmpeg_progress()
+        empty_progress = {
+            "percent": 0.0,
+            "time": "",
+            "speed": "",
+            "bandwidth": "",
+            "active": False,
+        }
+        for item in items:
+            item["ffmpeg_progress"] = ffmpeg_pct.get(
+                str(item["id"]), empty_progress
+            )
         return jsonify({"items": items, "ffmpeg_progress": ffmpeg_pct})
 
     @app.route("/api/queue/<int:queue_id>", methods=["DELETE"])

--- a/src/aniworld/web/static/queue.js
+++ b/src/aniworld/web/static/queue.js
@@ -32,6 +32,20 @@ function closeQueueModal() {
 
 let lastFfmpegProgress = {};
 
+function getItemFfmpegProgress(item) {
+  if (!item) return {};
+  if (item.ffmpeg_progress) return item.ffmpeg_progress;
+  if (!lastFfmpegProgress) return {};
+
+  const byId = lastFfmpegProgress[String(item.id)];
+  if (byId) return byId;
+
+  // Compatibility with older API shape while the page is still cached.
+  if (lastFfmpegProgress.active !== undefined) return lastFfmpegProgress;
+
+  return {};
+}
+
 function formatBandwidth(bwStr) {
   if (!bwStr) return "";
   const trimmed = String(bwStr).trim();
@@ -104,6 +118,7 @@ function renderQueue(items) {
 
   let html = "";
   visible.forEach((item) => {
+    const ffmpegProgress = getItemFfmpegProgress(item);
     const isRunning = item.status === "running";
     const isActive =
       isRunning || (item.status === "cancelled" && item.current_url);
@@ -146,8 +161,8 @@ function renderQueue(items) {
 
       // Combine episode progress with in-episode ffmpeg progress
       let ffPct = 0;
-      if (isRunning && lastFfmpegProgress.active && item.total_episodes > 0) {
-        ffPct = (lastFfmpegProgress.percent || 0) / item.total_episodes;
+      if (isRunning && ffmpegProgress.active && item.total_episodes > 0) {
+        ffPct = (ffmpegProgress.percent || 0) / item.total_episodes;
       }
       const combinedPct = Math.min(Math.round(epPct + ffPct), 100);
 
@@ -167,14 +182,16 @@ function renderQueue(items) {
       } else {
         let epDetail = item.current_episode + "/" + item.total_episodes + " episodes";
         if (seInfo) epDetail += " - " + seInfo;
-        if (lastFfmpegProgress.active && lastFfmpegProgress.percent > 0) {
-          const bw = formatBandwidth(lastFfmpegProgress.bandwidth || "");
+        if (ffmpegProgress.active && ffmpegProgress.percent > 0) {
+          const bw = formatBandwidth(ffmpegProgress.bandwidth || "");
           epDetail +=
             " (" +
-            lastFfmpegProgress.percent +
+            ffmpegProgress.percent +
             "%" +
             (bw ? " @ " + bw : "") +
             ")";
+        } else if (isRunning && seInfo) {
+          epDetail += " (Preparing...)";
         }
         label = epDetail;
       }


### PR DESCRIPTION
This took a little while because I split the previous larger change set into smaller more focused PRs after syncing with the latest upstream changes.

## What changed

- Add configurable parallel queue workers via `ANIWORLD_MAX_PARALLEL_DOWNLOADS`.
- Track FFmpeg progress per queue item instead of using only one global progress value.
- Return item-specific progress data from the queue API.
- Update the queue UI to show the correct progress for each running item.
- Show `(Preparing...)` while an item is running but FFmpeg progress has not started yet.

## Why

This makes the web queue more useful when multiple downloads are running at the same time and avoids progress from one item appearing on another item.
