### PR TITLE
Add aria2c download support and improve session handling for Doodstream downloads

### DIFF
--- a/src/aniworld/autodeps.py
+++ b/src/aniworld/autodeps.py
@@ -120,6 +120,14 @@ deps = {
         "Linux": {"package": "ffmpeg"},
         "Darwin": {"package": "ffmpeg"},
     },
+    "aria2c": {
+        "Windows": {
+            "package": "aria2.aria2",
+            "binary_names": ["aria2c.exe", "aria2c"],
+        },
+        "Linux": {"package": "aria2", "binary_names": ["aria2c"]},
+        "Darwin": {"package": "aria2", "binary_names": ["aria2c"]},
+    },
 }
 
 
@@ -394,6 +402,11 @@ class DependencyManager:
 # -----------------------------
 # Player paths
 # -----------------------------
+def get_aria2c_path() -> Path:
+    manager = DependencyManager()
+    return manager.fetch_binary("aria2c", prompt_user=False)
+
+
 def get_player_path() -> Path:
     manager = DependencyManager()
     use_iina = os.getenv("ANIWORLD_USE_IINA") == "1"

--- a/src/aniworld/config.py
+++ b/src/aniworld/config.py
@@ -111,7 +111,17 @@ LULUVDO_USER_AGENT = (
     "Mozilla/5.0 (Android 15; Mobile; rv:132.0) Gecko/132.0 Firefox/132.0"
 )
 
-GLOBAL_SESSION = Session(
+
+class _RobustSession(Session):
+    def request(self, method, url, **kwargs):
+        kwargs.setdefault("timeout", 30)
+        try:
+            return super().request(method, url, **kwargs)
+        except AttributeError:
+            return super().request(method, url, **kwargs)
+
+
+GLOBAL_SESSION = _RobustSession(
     resolver=["doh+google://"],
     headers={
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",

--- a/src/aniworld/extractors/provider/doodstream.py
+++ b/src/aniworld/extractors/provider/doodstream.py
@@ -3,15 +3,16 @@ import random
 import re
 import time
 import warnings
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
-import niquests
 from urllib3.exceptions import InsecureRequestWarning
 
 try:
-    from ...config import DEFAULT_USER_AGENT
+    from ...config import DEFAULT_USER_AGENT, GLOBAL_SESSION
+    from ...playwright.captcha import solve_captcha
 except ImportError:
-    from aniworld.config import DEFAULT_USER_AGENT
+    from aniworld.config import DEFAULT_USER_AGENT, GLOBAL_SESSION
+    from aniworld.playwright.captcha import solve_captcha
 
 warnings.simplefilter("ignore", InsecureRequestWarning)
 
@@ -20,7 +21,7 @@ warnings.simplefilter("ignore", InsecureRequestWarning)
 # -----------------------------
 DOODSTREAM_BASE_URL = "https://dood.li"
 RANDOM_STRING_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-PASS_MD5_PATTERN = r"\$\.get\('([^']*\/pass_md5\/[^']*)'"
+PASS_MD5_PATTERN = r"\$\.get\([\"']([^\"']*\/pass_md5\/[^\"']*)[\"']"
 TOKEN_PATTERN = r"token=([a-zA-Z0-9]+)"
 
 
@@ -32,6 +33,9 @@ def _get_headers(referer=None):
     return {
         "User-Agent": DEFAULT_USER_AGENT,
         "Referer": referer or f"{DOODSTREAM_BASE_URL}/",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Accept-Encoding": "gzip, deflate",
     }
 
 
@@ -51,9 +55,27 @@ def _generate_random_string(length=10):
 def _get_embed_page(embed_url, headers=None):
     """Fetch HTML content of the embed page."""
     headers = headers or _get_headers()
-    resp = niquests.get(embed_url, headers=headers, verify=False)
+    resp = GLOBAL_SESSION.get(embed_url, headers=headers, verify=False)
+    html = resp.text
+    if "Just a moment..." in html and "cloudflare" in html.lower():
+        logging.warning(
+            "Cloudflare challenge on Doodstream - solving via browser: %s", resp.url
+        )
+        solve_captcha(embed_url)
+        resp = GLOBAL_SESSION.get(embed_url, headers=headers, verify=False)
+        html = resp.text
+        if "Just a moment..." in html and "cloudflare" in html.lower():
+            raise ValueError(f"Doodstream Cloudflare challenge unsolvable: {resp.url}")
     resp.raise_for_status()
-    return resp.text
+    return html
+
+
+def _get_base_url(url):
+    """Return the scheme/netloc base URL for the active Doodstream mirror."""
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return DOODSTREAM_BASE_URL
+    return f"{parsed.scheme}://{parsed.netloc}"
 
 
 def _get_pass_md5_url(embed_html, embed_url):
@@ -62,7 +84,7 @@ def _get_pass_md5_url(embed_html, embed_url):
         PASS_MD5_PATTERN, embed_html, "pass_md5 URL", embed_url
     )
     if not pass_md5_url.startswith("http"):
-        pass_md5_url = urljoin(DOODSTREAM_BASE_URL, pass_md5_url)
+        pass_md5_url = urljoin(_get_base_url(embed_url), pass_md5_url)
     return pass_md5_url
 
 
@@ -80,13 +102,15 @@ def get_direct_link_from_doodstream(embed_url):
         raise ValueError("Embed URL cannot be empty")
 
     logging.info(f"Extracting Doodstream direct link from: {embed_url}")
-    headers = _get_headers(embed_url)
+    base_url = _get_base_url(embed_url)
+    embed_headers = _get_headers(f"{base_url}/")
+    md5_headers = _get_headers(embed_url)
 
-    embed_html = _get_embed_page(embed_url, headers)
+    embed_html = _get_embed_page(embed_url, embed_headers)
     pass_md5_url = _get_pass_md5_url(embed_html, embed_url)
     token = _get_token(embed_html, embed_url)
 
-    md5_resp = niquests.get(pass_md5_url, headers=headers, verify=False)
+    md5_resp = GLOBAL_SESSION.get(pass_md5_url, headers=md5_headers, verify=False)
     md5_resp.raise_for_status()
     video_base_url = md5_resp.text.strip()
     if not video_base_url:

--- a/src/aniworld/extractors/provider/vidmoly.py
+++ b/src/aniworld/extractors/provider/vidmoly.py
@@ -1,9 +1,9 @@
 import re
 
 try:
-    from ...config import GLOBAL_SESSION
+    from ...config import DEFAULT_USER_AGENT, GLOBAL_SESSION
 except ImportError:
-    from aniworld.config import GLOBAL_SESSION
+    from aniworld.config import DEFAULT_USER_AGENT, GLOBAL_SESSION
 
 # -----------------------------
 # Constants
@@ -19,7 +19,13 @@ PREVIEW_IMAGE_PATTERN = re.compile(
 # -----------------------------
 def _get_headers():
     """Return headers for Vidmoly requests."""
-    return {"Referer": "https://vidmoly.biz"}
+    return {
+        "User-Agent": DEFAULT_USER_AGENT,
+        "Referer": "https://vidmoly.biz/",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Accept-Encoding": "gzip, deflate",
+    }
 
 
 def _extract_regex(pattern, content, name, url):

--- a/src/aniworld/logger.py
+++ b/src/aniworld/logger.py
@@ -35,6 +35,7 @@ class ColorFormatter(logging.Formatter):
         )
 
         record.msg = f"{MSG_COLOR}{record.getMessage()}{RESET}"
+        record.args = None
 
         formatted = super().format(record)
 

--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -14,7 +14,7 @@ import ffmpeg
 from ...autodeps import DependencyManager
 
 try:
-    from ...autodeps import get_player_path, get_syncplay_path
+    from ...autodeps import get_aria2c_path, get_player_path, get_syncplay_path
     from ...config import (
         INVERSE_LANG_LABELS,
         LANG_CODE_MAP,
@@ -27,7 +27,7 @@ try:
         logger,
     )
 except ImportError:
-    from aniworld.autodeps import get_player_path, get_syncplay_path
+    from aniworld.autodeps import get_aria2c_path, get_player_path, get_syncplay_path
     from aniworld.config import (
         INVERSE_LANG_LABELS,
         LANG_CODE_MAP,
@@ -499,6 +499,121 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
         raise RuntimeError(f"ffmpeg error (rc={process.returncode}): {detail}")
 
 
+def _aria2c_bandwidth_to_mb(value, unit):
+    if unit == "GiB":
+        return value * 1024
+    if unit == "MiB":
+        return value
+    if unit == "KiB":
+        return value / 1024
+    return value / (1024 * 1024)
+
+
+def _try_aria2c_download(url, output_path, headers) -> bool:
+    """Download url with aria2c using multiple connections when available."""
+    try:
+        aria2c = str(get_aria2c_path())
+    except Exception as exc:
+        logger.debug(f"[Doodstream] aria2c unavailable: {exc}")
+        return False
+
+    cmd = [
+        aria2c,
+        "--max-connection-per-server=16",
+        "--split=16",
+        "--allow-overwrite=true",
+        "--auto-file-renaming=false",
+        "--console-log-level=warn",
+        "--summary-interval=1",
+        "--out",
+        output_path.name,
+        "--dir",
+        str(output_path.parent),
+    ]
+    for key, value in headers.items():
+        cmd += ["--header", f"{key}: {value}"]
+    cmd.append(url)
+
+    percent_pattern = re.compile(r"\((\d+)%\)")
+    bandwidth_pattern = re.compile(r"DL:([0-9.]+)(GiB|MiB|KiB|B)")
+
+    try:
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=False,
+        )
+    except Exception as exc:
+        logger.debug(f"[Doodstream] aria2c failed to start: {exc}")
+        return False
+
+    with _ffmpeg_progress_lock:
+        _ffmpeg_progress.update(
+            percent=0.0, time="", speed="", bandwidth="", active=True
+        )
+
+    buf = bytearray()
+    try:
+        while True:
+            char = process.stdout.read(1)
+            if not char:
+                break
+            if char not in (b"\r", b"\n"):
+                buf.extend(char)
+                continue
+            if not buf:
+                continue
+
+            line = buf.decode("utf-8", errors="replace")
+            buf.clear()
+            percent_match = percent_pattern.search(line)
+            if not percent_match:
+                continue
+
+            bandwidth = ""
+            bandwidth_match = bandwidth_pattern.search(line)
+            if bandwidth_match:
+                value = float(bandwidth_match.group(1))
+                unit = bandwidth_match.group(2)
+                bandwidth = f"{_aria2c_bandwidth_to_mb(value, unit):.1f} MB/s"
+
+            with _ffmpeg_progress_lock:
+                _ffmpeg_progress.update(
+                    percent=round(float(percent_match.group(1)), 1),
+                    time="",
+                    speed="",
+                    bandwidth=bandwidth,
+                    active=True,
+                )
+    finally:
+        with _ffmpeg_progress_lock:
+            _ffmpeg_progress.update(
+                percent=0.0, time="", speed="", bandwidth="", active=False
+            )
+
+    process.wait()
+    return process.returncode == 0 and output_path.exists()
+
+
+def _safe_unlink(path, retries=6, delay=0.5):
+    last_error = None
+    for attempt in range(retries):
+        try:
+            path.unlink()
+            return
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            last_error = exc
+            if attempt < retries - 1:
+                import time
+
+                time.sleep(delay)
+
+    logger.debug(f"Failed to remove temporary file {path}: {last_error}")
+
+
 def download(self):
     """Download required audio/video streams for an episode (AniWorld + s.to) with retry logic."""
     if platform.system() == "Windows":
@@ -580,6 +695,21 @@ def download(self):
                 temp_audio = self._episode_path.with_suffix(".temp_audio.mkv")
                 temp_video = self._episode_path.with_suffix(".temp_video.mkv")
                 temp_full = self._episode_path.with_suffix(".temp_full.mkv")
+                temp_dood = self._episode_path.with_suffix(".temp_dood.mp4")
+
+                if provider_name == "Doodstream":
+                    if _try_aria2c_download(stream_url, temp_dood, headers):
+                        logger.debug(
+                            "[Doodstream] aria2c download complete - using local file"
+                        )
+                        stream_url = str(temp_dood)
+                        input_kwargs = {}
+                    else:
+                        if temp_dood.exists():
+                            _safe_unlink(temp_dood)
+                        logger.debug(
+                            "[Doodstream] aria2c unavailable - falling back to FFmpeg"
+                        )
 
                 if full_stream_needed:
                     logger.debug(
@@ -615,7 +745,9 @@ def download(self):
                         os.replace(temp_full, self._episode_path)
 
                     if temp_full.exists():
-                        temp_full.unlink()
+                        _safe_unlink(temp_full)
+                    if temp_dood.exists():
+                        _safe_unlink(temp_dood)
                     return
 
                 if need_audio:
@@ -666,9 +798,9 @@ def download(self):
                 )
                 os.replace(output_path, self._episode_path)
 
-                for f in (temp_audio, temp_video):
+                for f in (temp_audio, temp_video, temp_dood):
                     if f.exists():
-                        f.unlink()
+                        _safe_unlink(f)
 
                 return
 
@@ -677,11 +809,12 @@ def download(self):
                     ".temp_full.mkv",
                     ".temp_audio.mkv",
                     ".temp_video.mkv",
+                    ".temp_dood.mp4",
                     ".new.mkv",
                 ):
                     temp = self._episode_path.with_suffix(suffix)
                     if temp.exists():
-                        temp.unlink()
+                        _safe_unlink(temp)
 
                 provider_errors[provider_name] = e
                 logger.warning(


### PR DESCRIPTION
## What changed

- Add `aria2c` support through autodeps for faster Doodstream downloads.
- Try Doodstream downloads with `aria2c` first and fall back to FFmpeg if unavailable or failing.
- Add progress parsing for `aria2c` so the existing progress UI can still update.
- Harden the Doodstream extractor:
  - use the shared global session
  - support active Doodstream mirror domains
  - improve headers
  - handle Cloudflare challenge retry through the existing captcha helper
- Improve Vidmoly request headers.
- Add a more robust global session with a default timeout.
- Make temporary file cleanup more resilient.
- Fix colored logger formatting by clearing consumed format args.
