### PR TITLE
fix(logger): safely restore LogRecord state during formatting to prevent TypeError in standard logging

### DIFF
--- a/src/aniworld/logger.py
+++ b/src/aniworld/logger.py
@@ -25,36 +25,63 @@ class ColorFormatter(logging.Formatter):
     """Formatter for colored stdout logs."""
 
     def format(self, record):
-        level_color = COLORS.get(record.levelno, RESET)
-        record.levelname = f"{level_color}{record.levelname}{RESET}"
+        orig_levelname = record.levelname
+        orig_msg = record.msg
+        orig_args = record.args
+        orig_func_info = getattr(record, "func_info", None)
+        orig_message = getattr(record, "message", None)
 
-        cwd = os.getcwd()
-        rel_path = os.path.relpath(record.pathname, cwd)
-        record.func_info = (
-            f"{FUNC_COLOR}{rel_path}:{record.lineno}:{record.funcName}{RESET}"
-        )
+        try:
+            level_color = COLORS.get(record.levelno, RESET)
+            record.levelname = f"{level_color}{record.levelname}{RESET}"
 
-        record.msg = f"{MSG_COLOR}{record.getMessage()}{RESET}"
+            cwd = os.getcwd()
+            rel_path = os.path.relpath(record.pathname, cwd)
+            record.func_info = (
+                f"{FUNC_COLOR}{rel_path}:{record.lineno}:{record.funcName}{RESET}"
+            )
 
-        formatted = super().format(record)
+            record.msg = f"{MSG_COLOR}{record.getMessage()}{RESET}"
+            record.args = None
 
-        # Color timestamp
-        parts = formatted.split(" - ", 1)
-        if len(parts) == 2:
-            timestamp, rest = parts
-            formatted = f"{TIME_COLOR}{timestamp}{RESET} - {rest}"
+            formatted = super().format(record)
 
-        return formatted
+            # Color timestamp
+            parts = formatted.split(" - ", 1)
+            if len(parts) == 2:
+                timestamp, rest = parts
+                formatted = f"{TIME_COLOR}{timestamp}{RESET} - {rest}"
+
+            return formatted
+        finally:
+            record.levelname = orig_levelname
+            record.msg = orig_msg
+            record.args = orig_args
+            if orig_func_info is not None:
+                record.func_info = orig_func_info
+            elif hasattr(record, "func_info"):
+                del record.func_info
+            if orig_message is not None:
+                record.message = orig_message
+            elif hasattr(record, "message"):
+                del record.message
 
 
 class PlainFormatter(logging.Formatter):
     """Formatter for plain file logs (no color)."""
 
     def format(self, record):
-        cwd = os.getcwd()
-        rel_path = os.path.relpath(record.pathname, cwd)
-        record.func_info = f"{rel_path}:{record.lineno}:{record.funcName}"
-        return super().format(record)
+        orig_func_info = getattr(record, "func_info", None)
+        try:
+            cwd = os.getcwd()
+            rel_path = os.path.relpath(record.pathname, cwd)
+            record.func_info = f"{rel_path}:{record.lineno}:{record.funcName}"
+            return super().format(record)
+        finally:
+            if orig_func_info is not None:
+                record.func_info = orig_func_info
+            elif hasattr(record, "func_info"):
+                del record.func_info
 
 
 # TODO: This does not respect env debug mode


### PR DESCRIPTION
# Description
## 🐛 Description
When running the Auto-Sync background worker (`_autosync_worker`), log calls containing string format arguments (e.g., `logger.info("Auto-sync skipped '%s' (%s)", title, lang)`) caused continuous crashes inside Python's logging infrastructure, spamming the log files with tracebacks:

```text
TypeError: not all arguments converted during string formatting
  File "logging/__init__.py", line 400, in getMessage
    msg = msg % self.args
```

## 🔍 Root Cause
In Python's standard `logging` module, a single `LogRecord` instance is passed across all configured handlers (`StreamHandler`, `FileHandler`).

Our custom `ColorFormatter` directly mutated `record.msg` by replacing it with the pre-formatted string (`record.getMessage()`), but did not clear `record.args`. When standard logging methods or subsequent formatters processed the exact same `LogRecord` afterwards, the logging engine attempted to re-interpolate string arguments (`record.msg % record.args`) on a string that had already been formatted and no longer contained `%s` placeholders.

## 🛠️ Solution
Refactored `ColorFormatter` and `PlainFormatter` in `src/aniworld/logger.py` to use a robust `try...finally` pattern:
- Cached the original attributes (`levelname`, `msg`, `args`, `func_info`, `message`) before formatting.
- Temporarily set `record.args = None` during `ColorFormatter.format()` after pre-formatting to prevent double-interpolation.
- Guaranteed complete restoration of original `LogRecord` attributes inside the `finally` block so mutations never leak across handlers or file outputs.

## 🧪 Verification
- Verified statically and tested formatting logic with multi-argument strings against both `ColorFormatter` and `PlainFormatter`.
- Confirmed that log messages format cleanly with ANSI colors in terminal outputs while writing clean, uncorrupted plain text to file logs without raising exceptions.