### PR TITLE
perf(common): reduce STALL_TIMEOUT and reconnect_delay_max for faster…

### DIFF
--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -307,7 +307,7 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
     """
 
     STALL_TIMEOUT = (
-        600  # 10 minutes without progress → kill (must exceed reconnect_delay_max=300)
+        60  # 60 seconds without progress → kill (must exceed reconnect_delay_max=30)
     )
 
     debug_mode = os.getenv("ANIWORLD_DEBUG_MODE", "0") == "1"
@@ -589,7 +589,7 @@ def _download_hls_stream(episode_path, stream_url, file_name, audio_lang="jpn"):
         input_kwargs = {
             "reconnect": 1,
             "reconnect_streamed": 1,
-            "reconnect_delay_max": 300,
+            "reconnect_delay_max": 30,
         }
 
         _run_ffmpeg_with_progress(
@@ -654,7 +654,7 @@ def download(self):
                 input_kwargs = {
                     "reconnect": 1,
                     "reconnect_streamed": 1,
-                    "reconnect_delay_max": 300,  # wait up to 5 min for connection recovery
+                    "reconnect_delay_max": 30,  # wait up to 30s for connection recovery
                 }
                 if headers:
                     header_list = [f"{k}: {v}" for k, v in headers.items()]


### PR DESCRIPTION
Reduces FFmpeg timeout parameters in `common.py` to prevent dead streams (e.g. `EOF` on expired tokens) from blocking the download queue for up to 10 minutes:

- **`reconnect_delay_max`**: Reduced from `300s` to `30s`
- **`STALL_TIMEOUT`**: Reduced from `600s` to `60s`

This implements a fail-fast behavior: if a download hangs or fails to reconnect within 60 seconds, the watchdog kills the process and immediately falls back to the next available provider.
