### PR TITLE
fix(entry.py): replace s.to with serienstream.to

### DIFF
--- a/src/aniworld/entry.py
+++ b/src/aniworld/entry.py
@@ -152,6 +152,9 @@ def aniworld():
 
         url = args.url[0] if args.url else search()
 
+        #FIX: replace s.to with serienstream.to to avoid issues with s.to being down
+        url = url.replace("://s.to", "://serienstream.to")
+
         provider = resolve_provider(url)
 
         # If provider is NOT AniWorld -> bypass menu


### PR DESCRIPTION
Replaces "s.to" with "serienstream.to" in input URLs before processing to prevent errors with old code base.