### PR TITLE
Hide Kinox & BurningSeries by default

### DIFF
--- a/src/aniworld/.env.example
+++ b/src/aniworld/.env.example
@@ -74,6 +74,19 @@ ANIWORLD_ANISKIP=0
 # 0 = off, 1 = on
 ANIWORLD_ENABLE_HTV=0
 
+# Enable the BurningSeries tab.
+# Disabled by default: BurningSeries is behind a geo-block and additionally
+# protected by Google reCAPTCHA, which we currently have no way to bypass.
+# Turn this on only if you can reach it yourself (e.g. correct region / VPN).
+# 0 = off, 1 = on
+ANIWORLD_ENABLE_BURNINGSERIES=0
+
+# Enable the Kinox tab.
+# Disabled by default: Kinox demands a captcha for every download, which we
+# currently have no way to bypass automatically.
+# 0 = off, 1 = on
+ANIWORLD_ENABLE_KINOX=0
+
 # ==============================
 # Player Integration
 # ==============================

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -1187,6 +1187,10 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
         if default_web_language not in LANG_LABELS.values():
             default_web_language = "German Dub"
         htv_enabled = os.environ.get("ANIWORLD_ENABLE_HTV", "0") == "1"
+        burningseries_enabled = (
+            os.environ.get("ANIWORLD_ENABLE_BURNINGSERIES", "0") == "1"
+        )
+        kinox_enabled = os.environ.get("ANIWORLD_ENABLE_KINOX", "0") == "1"
         return render_template(
             "index.html",
             lang_labels=LANG_LABELS,
@@ -1195,6 +1199,8 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             supported_providers=WORKING_PROVIDERS,
             default_web_language=default_web_language,
             htv_enabled=htv_enabled,
+            burningseries_enabled=burningseries_enabled,
+            kinox_enabled=kinox_enabled,
         )
 
     @app.route("/api/search", methods=["POST"])

--- a/src/aniworld/web/static/app.js
+++ b/src/aniworld/web/static/app.js
@@ -320,9 +320,18 @@ const htvTrendingGrid = document.getElementById("htvTrendingGrid");
 
 const segmentedThumb = document.getElementById("segmentedThumb");
 const htvEnabled = window.HTV_ENABLED;
-const sites = htvEnabled
-  ? ["aniworld", "mangafire", "sto", "burningseries", "megakino", "cineby", "kinox", "filmpalast", "htv"]
-  : ["aniworld", "mangafire", "sto", "burningseries", "megakino", "cineby", "kinox", "filmpalast"];
+const burningseriesEnabled = window.BURNINGSERIES_ENABLED;
+const kinoxEnabled = window.KINOX_ENABLED;
+// BurningSeries and Kinox are opt-in via .env (ANIWORLD_ENABLE_BURNINGSERIES /
+// ANIWORLD_ENABLE_KINOX) and hidden unless enabled, same as the Hanime tab.
+const sites = ["aniworld", "mangafire", "sto", "burningseries", "megakino", "cineby", "kinox", "filmpalast", "htv"].filter(
+  (site) => {
+    if (site === "htv") return htvEnabled;
+    if (site === "burningseries") return burningseriesEnabled;
+    if (site === "kinox") return kinoxEnabled;
+    return true;
+  },
+);
 
 // Movie-only sites behave like MegaKino (single item, no seasons).
 const movieSites = ["megakino", "filmpalast"];
@@ -477,7 +486,7 @@ function rebuildLanguageSelect() {
 // Restore site state from localStorage
 (function syncSiteState() {
   const saved = localStorage.getItem("selectedSite");
-  const initial = saved && saved !== "aniworld" && sites.includes(saved) && !(saved === "htv" && !htvEnabled) ? saved : "aniworld";
+  const initial = saved && saved !== "aniworld" && sites.includes(saved) ? saved : "aniworld";
   if (initial !== "aniworld") {
     switchSite(initial);
   } else {

--- a/src/aniworld/web/templates/index.html
+++ b/src/aniworld/web/templates/index.html
@@ -7,10 +7,14 @@
       <button class="segmented-btn active" id="labelAniworld" onclick="switchSite('aniworld')">AniWorld</button>
       <button class="segmented-btn" id="labelMangaFire" onclick="switchSite('mangafire')">MangaFire</button>
       <button class="segmented-btn" id="labelSto" onclick="switchSite('sto')">SerienStream</button>
+      {% if burningseries_enabled %}
       <button class="segmented-btn" id="labelBurningSeries" onclick="switchSite('burningseries')">BurningSeries</button>
+      {% endif %}
       <button class="segmented-btn" id="labelMegakino" onclick="switchSite('megakino')">MegaKino</button>
       <button class="segmented-btn" id="labelCineby" onclick="switchSite('cineby')">Cineby</button>
+      {% if kinox_enabled %}
       <button class="segmented-btn" id="labelKinox" onclick="switchSite('kinox')">Kinox</button>
+      {% endif %}
       <button class="segmented-btn" id="labelFilmPalast" onclick="switchSite('filmpalast')">FilmPalast</button>
       {% if htv_enabled %}
       <button class="segmented-btn" id="labelHtv" onclick="switchSite('htv')">Hanime</button>
@@ -119,6 +123,8 @@
       window.CINEBY_LANGS = { "1": "English Dub" };
       window.DEFAULT_WEB_LANGUAGE = {{ default_web_language | tojson }};
       window.HTV_ENABLED = {{ htv_enabled | tojson }};
+      window.BURNINGSERIES_ENABLED = {{ burningseries_enabled | tojson }};
+      window.KINOX_ENABLED = {{ kinox_enabled | tojson }};
     </script>
     <div class="episodes-header">
       <h3 data-i18n="index.episodes">Episodes</h3>


### PR DESCRIPTION
## What changed

The **Kinox** and **BurningSeries** tabs in the web UI are now **disabled by default** and hidden. Like the Hanime tab, each one can be re-enabled **individually** via `.env`.

Two new environment variables (default `0` = off):

| Variable | Effect |
|---|---|
| `ANIWORLD_ENABLE_BURNINGSERIES` | `1` = show the BurningSeries tab | | `ANIWORLD_ENABLE_KINOX` | `1` = show the Kinox tab |

Difference from the Hanime tab: these two are toggled **only via `.env`** — on purpose there is **no** toggle in the web UI settings.

## Why

- **BurningSeries** is behind a **geo-block** and additionally protected by **Google reCAPTCHA**, which we currently have no way to bypass.
- **Kinox** requires a **captcha for every download** that can't be solved automatically.

Since neither works reliably without manual intervention, they are hidden by default so users don't land on a broken/blocked view. Anyone who can reach the sites themselves (right region / VPN, or willing to solve the captcha manually) can enable them explicitly via `.env`.

## Files changed

- **`src/aniworld/.env.example`** – two new variables with an explanatory comment (reason for being disabled), default `0`.
- **`src/aniworld/web/app.py`** – the `index()` route reads both variables and passes `burningseries_enabled` / `kinox_enabled` to the template.
- **`src/aniworld/web/templates/index.html`** – Kinox and BurningSeries buttons wrapped in `{% if ... %}`; `window.BURNINGSERIES_ENABLED` / `window.KINOX_ENABLED` set.
- **`src/aniworld/web/static/app.js`** – the `sites` list filters out disabled sites; a previously stored (now disabled) tab in `localStorage` is not restored.

## Behavior

- **Default (nothing set):** no Kinox / BurningSeries tab visible.
- **`ANIWORLD_ENABLE_KINOX=1`:** only the Kinox tab appears.
- **`ANIWORLD_ENABLE_BURNINGSERIES=1`:** only the BurningSeries tab appears.
- Both are toggled independently of each other.

## Compatibility

- No breaking changes. Existing `.env` files get the new keys added automatically with default `0` on the next merge.
- No backend routes were changed — control happens (like Hanime) by hiding the tabs in the UI.