### PR TITLE
Fix Cineby series episodes and add German audio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ For full user guides, tutorials, and troubleshooting, visit the [official docume
   > still run without errors — when kinox blocks one, the queue shows a **"Solve on
   > Kinox"** button that opens the title page so you can solve the captcha and hit
   > **Retry**. Prefer the other sites for now.
+  >
+  > **Cineby German audio is unreliable:** Cineby lists a German audio track for
+  > almost everything, so the downloader offers **German Dub** accordingly — but in
+  > practice those German tracks often just don't work. That's a problem with Cineby's
+  > own sources, not with the downloader, so expect to fall back to English fairly often.
 - **Planned Releases** – Queue titles that aren't out yet; they download automatically once available
 - **Discord Request Bot** – Let others request movies/series from Discord, with owner approval
 - **Interface Language** – Switch the whole UI between English and German

--- a/src/aniworld/models/cineby/series.py
+++ b/src/aniworld/models/cineby/series.py
@@ -166,6 +166,164 @@ def resolve_stream_via_api(
     )
     return None
 
+
+# cineby's language labels line up with the rest of the app's dub labels so the
+# download pipeline's LANG maps ("German Dub" -> deu, "English Dub" -> eng) work
+# unchanged.
+ENGLISH_LABEL = "English Dub"
+GERMAN_LABEL = "German Dub"
+
+# The source API is mirrored across several "servers" (path prefixes). The first
+# (cdn) carries the original audio muxed into the stream — what cineby plays by
+# default. The others sometimes expose extra dub tracks (German among them) as a
+# separate audio rendition inside an HLS master, which is what the player's
+# "server" list surfaces. We scan the extras only to find a German rendition.
+CINEBY_DEFAULT_SERVER = "cdn/sources-with-title"
+CINEBY_EXTRA_SERVERS = (
+    "neon2/sources-with-title",
+    "downloader2/sources-with-title",
+    "tejo/sources-with-title",
+    "1movies/sources-with-title",
+)
+
+# Availability is stable per title but costs several requests to probe, so cache
+# it per (media_type, tmdb, season, episode). Stores the label list plus which
+# server carried German — never a stream URL, since those hold short-lived tokens
+# and must be re-resolved fresh at download time.
+_LANG_DETECT_CACHE = {}
+
+
+def _fetch_decrypted_sources(
+    endpoint, media_type, tmdb_id, title, year, imdb_id, season, episode, attempts=2
+):
+    """Fetch + decrypt one server's ``enc=2`` sources blob. Returns dict or None.
+
+    Same seed/decrypt dance as ``resolve_stream_via_api`` but for an arbitrary
+    server endpoint and returning the whole payload (``{sources, subtitles}``)
+    instead of a single URL, so callers can inspect audio renditions.
+    """
+    from .streamcrypto import decrypt_sources
+
+    last_err = None
+    for attempt in range(attempts):
+        try:
+            seed_resp = _fetch(f"{WINGS_API}/seed", params={"mediaId": tmdb_id})
+            if seed_resp.status_code != 200:
+                raise RuntimeError(f"seed HTTP {seed_resp.status_code}")
+            seed = (seed_resp.json() or {}).get("seed")
+            if not seed:
+                raise RuntimeError("no seed in response")
+            params = {
+                "title": title or "",
+                "mediaType": media_type,
+                "year": year or "",
+                "episodeId": episode or 1,
+                "seasonId": season or 1,
+                "tmdbId": tmdb_id,
+                "imdbId": imdb_id or "",
+                "enc": "2",
+                "seed": seed,
+            }
+            src_resp = _fetch(f"{WINGS_API}/{endpoint}", params=params)
+            if src_resp.status_code != 200:
+                raise RuntimeError(f"sources HTTP {src_resp.status_code}")
+            if src_resp.text.lstrip().startswith("{"):
+                raise RuntimeError(f"sources error: {src_resp.text[:80]!r}")
+            return decrypt_sources(src_resp.text, seed, int(tmdb_id))
+        except Exception as exc:  # noqa: BLE001 - retry with a fresh seed
+            last_err = exc
+            logger.debug(
+                f"cineby {endpoint} fetch attempt {attempt + 1}/{attempts} failed: {exc}"
+            )
+            if attempt + 1 < attempts:
+                time.sleep(1.0 * (attempt + 1))
+    logger.debug(f"cineby {endpoint} sources unavailable for tmdb {tmdb_id}: {last_err}")
+    return None
+
+
+def _hls_master_from_sources(sources):
+    """Return the HLS master URL from a decrypted sources list, or None.
+
+    Prefers an explicit ``type == "hls"`` source (the multi-audio servers tag
+    them); falls back to any ``.m3u8`` URL. DASH (``.mpd``) is skipped — the
+    downloader only speaks HLS.
+    """
+    for src in sources or []:
+        if (src.get("type") or "").lower() == "hls" and src.get("url"):
+            return src["url"]
+    for src in sources or []:
+        url = src.get("url") or ""
+        if ".m3u8" in url:
+            return url
+    return None
+
+
+def _german_master_url(media_type, tmdb_id, title, year, imdb_id, season, episode, endpoint):
+    """Freshly resolve the German-carrying server's HLS master URL (or None)."""
+    data = _fetch_decrypted_sources(
+        endpoint, media_type, tmdb_id, title, year, imdb_id, season, episode
+    )
+    if not data:
+        return None
+    return _hls_master_from_sources(data.get("sources"))
+
+
+def detect_audio_languages(
+    media_type, tmdb_id, title, year, imdb_id, season, episode, probe=True
+):
+    """Probe cineby's servers for the audio languages available for a title.
+
+    English (the original, muxed audio) is always offered — that's how cineby
+    plays by default. The extra servers are scanned for a German audio rendition
+    (matched exactly as the HLS downloader will match it); the first server that
+    has one is remembered so the download can go straight to it. Result is cached
+    per episode. Returns ``{"labels": [...], "german_server": <endpoint|None>}``.
+
+    ``probe=False`` returns the cached result if present, otherwise an
+    English-only answer *without* touching the network or caching it — used on
+    the episode-listing hot path so the several-request scan never blocks the
+    list from rendering (the language dropdown probes for real separately).
+    """
+    # Availability (and which server carries German) is a title-level property,
+    # stable across episodes, so cache it per title — the season/episode passed
+    # only pick which episode gets probed. The German URL itself is never cached;
+    # stream_url re-resolves it fresh per episode (its token expires).
+    key = (media_type, str(tmdb_id))
+    if key in _LANG_DETECT_CACHE:
+        return _LANG_DETECT_CACHE[key]
+    if not probe:
+        return {"labels": [ENGLISH_LABEL], "german_server": None}
+
+    from ..common.hls import rendition_languages
+
+    labels = [ENGLISH_LABEL]
+    german_server = None
+    for endpoint in CINEBY_EXTRA_SERVERS:
+        data = _fetch_decrypted_sources(
+            endpoint, media_type, tmdb_id, title, year, imdb_id, season, episode
+        )
+        if not data:
+            continue
+        master = _hls_master_from_sources(data.get("sources"))
+        if not master:
+            continue
+        try:
+            text = _fetch(master).text
+        except Exception as exc:  # noqa: BLE001 - unreachable mirror, try next server
+            logger.debug(f"cineby manifest fetch failed for {endpoint}: {exc}")
+            continue
+        if not text.lstrip().startswith("#EXTM3U"):
+            continue
+        if "deu" in rendition_languages(text, master):
+            labels.append(GERMAN_LABEL)
+            german_server = endpoint
+            break
+
+    result = {"labels": labels, "german_server": german_server}
+    _LANG_DETECT_CACHE[key] = result
+    return result
+
+
 _TMDB_HEADERS = {
     "Accept-Encoding": "gzip, deflate",
     "Origin": CINEBY_BASE,
@@ -220,7 +378,12 @@ def cineby_season_url(media_type, tmdb_id, season):
 
 def parse_cineby_url(url):
     """Return (media_type, tmdb_id, season, episode) from a cineby URL."""
-    path = re.sub(r"^https?://[^/]+", "", url).strip("/")
+    path = re.sub(r"^https?://[^/]+", "", url)
+    # Drop any query string / fragment before splitting: season URLs carry the
+    # number as ``?s=<n>`` (see cineby_season_url), and leaving it attached would
+    # glue it onto the tmdb id (e.g. ``125988?s=2``), making every downstream
+    # TMDB path malformed so no episodes come back.
+    path = path.split("#", 1)[0].split("?", 1)[0].strip("/")
     parts = path.split("/")
     if len(parts) >= 2 and parts[0] == "movie":
         return "movie", parts[1], None, None
@@ -262,6 +425,7 @@ class CinebyEpisode:
 
         self.__selected_path = None
         self.__stream_url = None
+        self.__lang_detect = None
 
         self.__base_folder = None
         self.__folder_path = None
@@ -349,12 +513,49 @@ class CinebyEpisode:
 
     @property
     def selected_language(self):
-        # cineby streams carry the original (mostly English) audio.
-        return "English Dub"
+        # cineby's default (cdn) stream carries the original audio, labelled
+        # "English Dub"; German is offered only for titles that actually have a
+        # German audio rendition (see available_language_labels).
+        return self.__selected_language_param or ENGLISH_LABEL
 
     @selected_language.setter
     def selected_language(self, value):
-        pass  # single language; ignore
+        self.__selected_language_param = value or None
+        self.__stream_url = None  # re-resolve for the newly selected language
+
+    # ---- language detection -------------------------------------------------
+    def _detect_languages(self):
+        """Cached per-episode probe of which dub languages cineby has."""
+        if self.__lang_detect is None:
+            meta = self._meta or {}
+            title = meta.get("title") or meta.get("name") or self.title
+            year = _year(meta.get("release_date") or meta.get("first_air_date"))
+            imdb = meta.get("imdb_id") or ""
+            season = 1 if self.is_movie else self.season_number
+            episode = 1 if self.is_movie else self.episode_number
+            try:
+                self.__lang_detect = detect_audio_languages(
+                    self.media_type, self.tmdb_id, title, year, imdb, season, episode
+                )
+            except Exception as exc:  # noqa: BLE001 - never block on detection
+                logger.debug(f"cineby language detection failed: {exc}")
+                self.__lang_detect = {"labels": [ENGLISH_LABEL], "german_server": None}
+        return self.__lang_detect
+
+    @property
+    def available_language_labels(self):
+        return self._detect_languages().get("labels", [ENGLISH_LABEL])
+
+    @property
+    def _wants_german(self):
+        return self.selected_language == GERMAN_LABEL
+
+    @property
+    def _separate_audio_rendition(self):
+        # German audio lives as a standalone rendition inside a multi-audio HLS
+        # master, so the shared download() must select it rather than take the
+        # muxed default. English (the default) never needs this.
+        return self._wants_german
 
     @property
     def selected_provider(self):
@@ -370,7 +571,11 @@ class CinebyEpisode:
     # ---- provider surface (single implicit provider) ------------------------
     @property
     def provider_data(self):
-        return {(Audio.ENGLISH, Subtitles.NONE): {"Cineby": self.url}}
+        labels = self.available_language_labels
+        data = {(Audio.ENGLISH, Subtitles.NONE): {"Cineby": self.url}}
+        if GERMAN_LABEL in labels:
+            data[(Audio.GERMAN, Subtitles.NONE)] = {"Cineby": self.url}
+        return data
 
     def provider_link(self, language=None, provider=None):
         return self.url
@@ -381,17 +586,40 @@ class CinebyEpisode:
     @property
     def stream_url(self):
         if self.__stream_url is None:
+            meta = self._meta or {}
+            title = meta.get("title") or meta.get("name") or self.title
+            year = _year(meta.get("release_date") or meta.get("first_air_date"))
+            imdb = meta.get("imdb_id") or ""
+            season = 1 if self.is_movie else self.season_number
+            episode = 1 if self.is_movie else self.episode_number
+
+            # German audio comes from a different server than the default one,
+            # as a separate rendition inside its HLS master. Resolve that master
+            # fresh (its URL carries a short-lived token) from the server that
+            # detection found German on; fail clearly if none has it.
+            if self._wants_german:
+                german_server = self._detect_languages().get("german_server")
+                if not german_server:
+                    raise RuntimeError(
+                        f"cineby: no German audio available for '{self.title}'."
+                    )
+                master = _german_master_url(
+                    self.media_type, self.tmdb_id, title, year, imdb,
+                    season, episode, german_server,
+                )
+                if not master:
+                    raise RuntimeError(
+                        f"cineby: could not resolve the German stream for "
+                        f"'{self.title}' (server {german_server} unreachable)."
+                    )
+                self.__stream_url = master
+                return self.__stream_url
+
             m3u8 = None
 
             # Preferred: resolve straight from cineby's source API and decrypt
             # it — no browser, so it can't be defeated by a flaky headless run.
             try:
-                meta = self._meta or {}
-                title = meta.get("title") or meta.get("name") or self.title
-                year = _year(meta.get("release_date") or meta.get("first_air_date"))
-                imdb = meta.get("imdb_id") or ""
-                season = 1 if self.is_movie else self.season_number
-                episode = 1 if self.is_movie else self.episode_number
                 m3u8 = resolve_stream_via_api(
                     self.media_type, self.tmdb_id, title, year, imdb, season, episode
                 )
@@ -552,7 +780,14 @@ class CinebySeason:
 
     @property
     def language_labels(self):
-        return ["English Dub"]
+        # Availability is a per-title property (German either exists for the show
+        # or it doesn't), so defer to the series-level probe instead of testing
+        # every season — see CinebySeries.available_language_labels.
+        try:
+            return list(self.series.available_language_labels)
+        except Exception as exc:  # noqa: BLE001 - never break the episode listing
+            logger.debug(f"cineby season language labels failed: {exc}")
+            return [ENGLISH_LABEL]
 
     def download(self):
         for episode in self.episodes:
@@ -576,6 +811,7 @@ class CinebySeries:
         self.is_movie = self.media_type == "movie"
         self.__meta = None
         self.__seasons = None
+        self.__lang_labels = None
 
     @property
     def _meta(self):
@@ -585,6 +821,27 @@ class CinebySeries:
             else:
                 self.__meta = tmdb_get(f"/tv/{self.tmdb_id}") or {}
         return self.__meta
+
+    @property
+    def available_language_labels(self):
+        """Dub labels offered for this title (English always; German if present).
+
+        Cache-only: reports German once the per-title probe (run by the language
+        dropdown via ``/api/providers``) has cached its result, but never probes
+        itself — it feeds the episode-listing badges, which must not block on a
+        multi-request server scan. So on a series' first open the badges read
+        English-only and gain German after the dropdown loads.
+        """
+        if self.__lang_labels is None:
+            meta = self._meta or {}
+            title = meta.get("title") or meta.get("name") or self.title
+            year = _year(meta.get("release_date") or meta.get("first_air_date"))
+            imdb = meta.get("imdb_id") or ""
+            detected = detect_audio_languages(
+                self.media_type, self.tmdb_id, title, year, imdb, 1, 1, probe=False
+            )
+            self.__lang_labels = detected.get("labels", [ENGLISH_LABEL])
+        return self.__lang_labels
 
     @property
     def title(self):

--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -833,6 +833,36 @@ def _download_hls_manual(m3u8_url, headers, temp_ts, label=""):
             )
 
 
+def _hls_rendition_download(stream_url, temp_prefix, headers, audio_code, ep_label):
+    """Fetch an HLS stream, selecting the ``audio_code`` audio rendition.
+
+    Used when the wanted audio (e.g. a German dub on cineby) is a *separate*
+    ``#EXT-X-MEDIA:TYPE=AUDIO`` rendition inside a multi-audio master rather than
+    the muxed default — the plain FFmpeg/manual paths would grab the default
+    track instead. Returns ``(video_path, audio_path)`` (``audio_path`` is None
+    when the stream turned out to be muxed after all), or None when the parallel
+    downloader can't handle the playlist and the caller should fall back.
+    """
+    from .hls import HLSUnsupported, download_hls_parallel
+
+    try:
+        written = download_hls_parallel(
+            stream_url,
+            temp_prefix,
+            headers=headers,
+            preferred_audio_lang=audio_code,
+            label=ep_label,
+        )
+    except HLSUnsupported as exc:
+        logger.debug(f"[HLS] rendition download unsupported ({exc}); falling back")
+        return None
+    if not written:
+        return None
+    video = written[0]
+    audio = written[1] if len(written) >= 2 else None
+    return video, audio
+
+
 def _download_full_stream(
     stream_url,
     temp_full,
@@ -965,6 +995,12 @@ def download(self):
 
                 full_stream_needed = need_audio and need_video
 
+                # Some providers (cineby's German dub) serve the wanted audio as
+                # a separate HLS rendition rather than the muxed default; the
+                # episode opts into rendition-aware fetching so we pick the right
+                # track instead of the default one.
+                select_rendition = getattr(self, "_separate_audio_rendition", False)
+
                 temp_audio = self._episode_path.with_suffix(".temp_audio.mkv")
                 temp_video = self._episode_path.with_suffix(".temp_video.mkv")
                 temp_full = self._episode_path.with_suffix(".temp_full.mkv")
@@ -979,16 +1015,49 @@ def download(self):
                         stream_metadata["metadata:s:v:0"] = f"language={sub_video_code}"
 
                     video_codec = get_video_codec()
-                    _download_full_stream(
-                        stream_url,
-                        temp_full,
-                        input_kwargs,
-                        headers,
-                        stream_metadata,
-                        video_codec,
-                        ep_label,
-                        audio_code,
-                    )
+                    rendition_done = False
+                    if select_rendition:
+                        from .hls import cleanup_temp_files
+
+                        temp_prefix = temp_full.with_suffix(".hlswork")
+                        result = _hls_rendition_download(
+                            stream_url, temp_prefix, headers, audio_code, ep_label
+                        )
+                        if result is not None:
+                            video_path, audio_path = result
+                            try:
+                                if audio_path is not None:
+                                    node = ffmpeg.output(
+                                        ffmpeg.input(str(video_path)).video,
+                                        ffmpeg.input(str(audio_path)).audio,
+                                        str(temp_full),
+                                        vcodec=video_codec,
+                                        acodec=video_codec,
+                                        **stream_metadata,
+                                    )
+                                else:
+                                    node = ffmpeg.input(str(video_path)).output(
+                                        str(temp_full),
+                                        vcodec=video_codec,
+                                        acodec=video_codec,
+                                        **stream_metadata,
+                                    )
+                                _run_ffmpeg_with_progress(node, label=ep_label)
+                                rendition_done = True
+                            finally:
+                                cleanup_temp_files(temp_prefix)
+
+                    if not rendition_done:
+                        _download_full_stream(
+                            stream_url,
+                            temp_full,
+                            input_kwargs,
+                            headers,
+                            stream_metadata,
+                            video_codec,
+                            ep_label,
+                            audio_code,
+                        )
 
                     if self._episode_path.exists():
                         inputs = [
@@ -1010,15 +1079,42 @@ def download(self):
                 if need_audio:
                     logger.debug(f"[DOWNLOADING] audio stream via {provider_name}")
                     video_codec = get_video_codec()
-                    _run_ffmpeg_with_progress(
-                        ffmpeg.input(stream_url, **input_kwargs).output(
-                            str(temp_audio),
-                            acodec=video_codec,
-                            map="0:a:0?",
-                            **{"metadata:s:a:0": f"language={audio_code}"},
-                        ),
-                        label=ep_label,
-                    )
+                    audio_done = False
+                    if select_rendition:
+                        # Pull just the wanted audio rendition (e.g. the German
+                        # dub) rather than the master's default track.
+                        from .hls import cleanup_temp_files
+
+                        temp_prefix = temp_audio.with_suffix(".hlswork")
+                        result = _hls_rendition_download(
+                            stream_url, temp_prefix, headers, audio_code, ep_label
+                        )
+                        if result is not None:
+                            _, audio_path = result
+                            audio_src = audio_path or result[0]
+                            try:
+                                _run_ffmpeg_with_progress(
+                                    ffmpeg.input(str(audio_src)).output(
+                                        str(temp_audio),
+                                        acodec=video_codec,
+                                        map="0:a:0?",
+                                        **{"metadata:s:a:0": f"language={audio_code}"},
+                                    ),
+                                    label=ep_label,
+                                )
+                                audio_done = True
+                            finally:
+                                cleanup_temp_files(temp_prefix)
+                    if not audio_done:
+                        _run_ffmpeg_with_progress(
+                            ffmpeg.input(stream_url, **input_kwargs).output(
+                                str(temp_audio),
+                                acodec=video_codec,
+                                map="0:a:0?",
+                                **{"metadata:s:a:0": f"language={audio_code}"},
+                            ),
+                            label=ep_label,
+                        )
 
                 if need_video:
                     logger.debug(f"[DOWNLOADING] video stream via {provider_name}")

--- a/src/aniworld/models/common/hls.py
+++ b/src/aniworld/models/common/hls.py
@@ -236,6 +236,31 @@ def _select_audio_rendition(renditions, group_id, preferred_lang):
     return candidates[0]
 
 
+def rendition_languages(master_text, base_url=""):
+    """Return the ffmpeg lang codes present as *separate* audio renditions.
+
+    Given an HLS master playlist, report which of the languages this downloader
+    can select (``_LANG_PREFIXES``) appear as their own ``#EXT-X-MEDIA:TYPE=AUDIO``
+    rendition — matched the exact same way ``_select_audio_rendition`` matches
+    them, so "detected as available" and "selectable at download time" never
+    disagree. Used by cineby to decide whether e.g. a German dub exists before
+    offering it.
+    """
+    _, renditions = _parse_master_playlist(master_text, base_url)
+    found = set()
+    for code, prefixes in _LANG_PREFIXES.items():
+        hints = _LANG_NAME_HINTS.get(code, ())
+        for rendition in renditions:
+            language = (rendition.language or "").lower()
+            name = (rendition.name or "").lower()
+            if (language and language.startswith(prefixes)) or any(
+                hint in name for hint in hints
+            ):
+                found.add(code)
+                break
+    return found
+
+
 def _parse_media_playlist(text, base_url):
     """Return (segments, init_uri) where each segment is (uri, key, sequence)."""
     if "#EXT-X-ENDLIST" not in text:

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -1681,8 +1681,16 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             if prov.name == "MangaFire":
                 return jsonify({"providers": {}})
             if prov.name == "Cineby":
-                # Single implicit provider; stream is captured from the site.
-                return jsonify({"providers": {"English Dub": ["Cineby"]}})
+                # Single implicit provider, but the audio language varies: the
+                # original is always there, German only when the title has a
+                # German audio rendition. Probe the given episode to find out.
+                labels = ["English Dub"]
+                try:
+                    episode = prov.episode_cls(url=url)
+                    labels = list(episode.available_language_labels) or labels
+                except Exception as exc:
+                    logger.warning(f"Cineby language detection failed: {exc}")
+                return jsonify({"providers": {label: ["Cineby"] for label in labels}})
             if prov.name == "MegaKino":
                 episode = prov.episode_cls(url=url, selected_language="German Dub")
             else:

--- a/src/aniworld/web/templates/index.html
+++ b/src/aniworld/web/templates/index.html
@@ -120,7 +120,10 @@
       window.KINOX_LANGS = { "1": "German Dub", "2": "English Dub" };
       window.BURNINGSERIES_LANGS = { "1": "German Dub", "2": "English Dub" };
       window.FILMPALAST_LANGS = { "1": "German Dub", "2": "English Dub" };
-      window.CINEBY_LANGS = { "1": "English Dub" };
+      // German Dub is only kept visible for titles that actually have it —
+      // /api/providers reports the available dubs per title and the language
+      // select hides the ones it omits.
+      window.CINEBY_LANGS = { "4": "English Dub", "1": "German Dub" };
       window.DEFAULT_WEB_LANGUAGE = {{ default_web_language | tojson }};
       window.HTV_ENABLED = {{ htv_enabled | tojson }};
       window.BURNINGSERIES_ENABLED = {{ burningseries_enabled | tojson }};


### PR DESCRIPTION
- Fix episode fetching for Cineby series: parse_cineby_url stripped the query string so seasons no longer resolve to 0 episodes
- Add per-title German audio: offer "German Dub" only when Cineby actually has a German track, and download it by selecting that audio rendition from the HLS master
- Note the English-only limitation in the README