### PR TITLE
feat(playwright): merge MediaForge's hardened captcha solver into ani…

### DIFF
--- a/src/aniworld/.env.example
+++ b/src/aniworld/.env.example
@@ -87,6 +87,67 @@ ANIWORLD_ENABLE_BURNINGSERIES=0
 # 0 = off, 1 = on
 ANIWORLD_ENABLE_KINOX=0
 
+
+# ==============================
+# Captcha Solver Settings
+# ==============================
+# Fine-tuning for the Cloudflare Turnstile captcha solver (playwright/captcha.py).
+# All of these are optional — the defaults already work for most setups.
+
+# Never auto-click a captcha widget - only your own click (CLI window / Web UI) counts.
+# 0 = off (auto-solve), 1 = on (manual only)
+ANIWORLD_CAPTCHA_MANUAL=0
+
+# Show the captcha browser window instead of pushing it off-screen.
+# 0 = off (hidden), 1 = on (visible)
+ANIWORLD_CAPTCHA_VISIBLE=0
+
+# Solve timeout in seconds. Leave empty to use the built-in default
+# (300s for the standalone solver, 90s for the serienstream.to modal flow).
+ANIWORLD_CAPTCHA_TIMEOUT=
+
+# Disable the network ad-blocker used during captcha solving.
+# Try turning this on if a captcha page won't load.
+# 0 = adblock on, 1 = adblock off
+ANIWORLD_NO_ADBLOCK=0
+
+# Disable auto-closing of pop-up ad tabs opened during the serienstream.to modal flow.
+# 0 = guard on, 1 = guard off
+ANIWORLD_CAPTCHA_NO_ADTAB_GUARD=0
+
+# Disable removal of invisible full-page ad-overlay links that can hijack clicks.
+# 0 = removal on, 1 = removal off
+ANIWORLD_CAPTCHA_NO_OVERLAY_REMOVAL=0
+
+# Disable syncing the HTTP session's User-Agent to the solving browser's real UA.
+# 0 = sync on, 1 = sync off
+ANIWORLD_CAPTCHA_NO_UA_SYNC=0
+
+# Spoof the WebGL renderer string (Intel/Mesa) to mask SwiftShader on GPU-less
+# servers/Docker. Usually not needed - leave off unless you're troubleshooting.
+# 0 = off, 1 = on
+ANIWORLD_SPOOF_WEBGL=0
+
+# Force a persistent Chromium profile (keeps a warm cf_clearance cookie across
+# solves) even outside Docker, where it is off by default.
+# 0 = off, 1 = on
+ANIWORLD_PERSISTENT_PROFILE=0
+
+# Force a fresh (non-persistent) browser profile every solve, even inside
+# Docker, where persistence is normally on by default.
+# 0 = off, 1 = on
+ANIWORLD_NO_PERSISTENT_PROFILE=0
+
+# Custom directory for the persistent Chromium profile.
+# Leave empty to use the default: ~/.aniworld/browser-profile
+ANIWORLD_BROWSER_PROFILE=
+
+# Manually flag the process as running in Docker (normally auto-detected via
+# /.dockerenv). Affects the persistent-profile default and a few launch args.
+# 0 = off, 1 = on
+ANIWORLD_DOCKER=0
+
+
 # ==============================
 # Player Integration
 # ==============================

--- a/src/aniworld/models/s_to/episode.py
+++ b/src/aniworld/models/s_to/episode.py
@@ -309,7 +309,8 @@ class SerienstreamEpisode:
                 language_label = _lang_map.get(audio, "Deutsch")
 
                 result = solve_sto_modal(
-                    self.url, self.selected_provider, language_label
+                    self.url, self.selected_provider, language_label,
+                    redirect_url=self.redirect_url,
                 )
                 self.__provider_url = result if result else resp.url
 

--- a/src/aniworld/playwright/captcha.py
+++ b/src/aniworld/playwright/captcha.py
@@ -1,25 +1,516 @@
-import queue as _queue_module
-import random as _random
+"""Cloudflare Turnstile / CAPTCHA solving via a real (patchright) browser.
+
+Ported/merged from MediaForge (https://github.com/PD-Codes/MediaForge) by
+PD-Codes — the hardened detection/solving logic below (ad-overlay defence,
+network ad-blocking, fingerprint hardening, multi-widget challenge solver)
+originates there and was adapted to this project (env vars renamed
+MEDIAFORGE_* -> ANIWORLD_*, DNS-routing dropped, AniWorld-Downloader-only
+helpers such as the hanime/cineby stream sniffers kept as-is).
+
+Streaming sites fronted by Cloudflare (serienstream.to, aniworld.to,
+filmpalast.to, ...) occasionally serve a Turnstile challenge instead of the
+requested page. This module opens a hardened, fingerprint-resistant Chromium
+context to solve it:
+
+  - is_captcha_page(): cheap HTML/status-code sniff, called by extractors
+    (e.g. aniworld.extractors.provider.voe) before falling back to a
+    browser-based solve.
+  - solve_captcha(): generic solver for a standalone CAPTCHA page. Runs
+    headed in CLI mode, or streams screenshots/accepts clicks from the Web UI
+    when a queue_id is set (interactive mode).
+  - solve_sto_modal(): serienstream.to-specific flow that clicks a provider's
+    play button to trigger its in-page Turnstile modal, then extracts the
+    resulting player-iframe URL (e.g. voe.sx/e/...).
+  - playwright_get_iframe_url() / playwright_get_hanime_stream_url() /
+    playwright_get_cineby_stream_url(): headless stream-URL sniffers for
+    providers whose embed only exists after client-side JS runs. Not part of
+    the captcha solver proper, kept here for historical reasons.
+
+Also implements ad-overlay removal, network ad-blocking during the solve,
+and fingerprint hardening (WebGL renderer spoof, persistent profile) to keep
+Cloudflare's bot score low. Every behavior toggle below reads a plain
+ANIWORLD_* environment variable (set it in your .env) — there is no
+Web-UI settings screen for this, unlike the ad-overlay/adblock/timeout knobs
+which all have sane defaults already.
+"""
+
 import threading as _threading
+import queue as _queue_module
 import time as _time
+import random as _random
 
 # Threading-local: set queue_id from the web worker to enable interactive mode
 _local = _threading.local()
 
-# Active captcha sessions keyed by queue_id (int)
+# Active captcha sessions keyed by queue_id (int).
+# Used by: aniworld.web.app (polls status, forwards user clicks from the Web UI).
 _active_sessions = {}
 _active_sessions_lock = _threading.Lock()
 
-# Optional hooks set by app.py to avoid circular imports
+# Optional hooks set by aniworld.web.app to avoid circular imports
 _on_captcha_start = None  # callable(queue_id: int, url: str)
-_on_captcha_end = None  # callable(queue_id: int)
+_on_captcha_end = None    # callable(queue_id: int)
 
-# Global captcha state for status polling
+# Global captcha state for status polling (CLI / non-queue callers)
 _captcha_state_lock = _threading.Lock()
 _captcha_state = None  # None or {"url": ..., "started_at": ..., "solved": bool}
 
 # Serialise concurrent solve attempts
 _captcha_lock = _threading.Lock()
+
+# ---------------------------------------------------------------------------
+# Ad-overlay defence
+# ---------------------------------------------------------------------------
+
+# Known video-provider netlocs — new browser tabs on these domains are the
+# actual player; any other new tab is treated as an ad and closed immediately.
+_KNOWN_PROVIDER_NETLOCS = {
+    "voe.sx",
+    "vidoza.net", "vidoza.to",
+    "streamtape.com", "streamtape.to",
+    "doodstream.com", "dood.to", "dood.watch",
+    "filemoon.sx", "filemoon.to",
+    "vidmoly.to", "vidmoly.net", "vidmoly.biz",
+    "luluvdo.com",
+    "vidara.to",
+    "veev.to",
+}
+
+# JavaScript that removes transparent full-viewport overlay <a> elements.
+# serienstream.to sometimes injects an invisible <a target="_blank"> that
+# covers the entire page so that any click opens an ad tab.
+_REMOVE_AD_OVERLAYS_JS = """
+() => {
+  try {
+    document.querySelectorAll('a').forEach(el => {
+      const r  = el.getBoundingClientRect();
+      const cs = window.getComputedStyle(el);
+      const bigEnough  = r.width  > window.innerWidth  * 0.4
+                      && r.height > window.innerHeight * 0.4;
+      const invisible  = parseFloat(cs.opacity) < 0.05
+                      || cs.visibility === 'hidden'
+                      || cs.pointerEvents === 'none';
+      const positioned = cs.position === 'fixed' || cs.position === 'absolute';
+      if (bigEnough && positioned && (invisible || el.getAttribute('target') === '_blank')) {
+        el.remove();
+      }
+    });
+  } catch(e) {}
+}
+"""
+
+
+def _remove_ad_overlays(page) -> None:
+    """Remove invisible full-page ad-overlay <a> elements before clicking."""
+    if _env_flag("ANIWORLD_CAPTCHA_NO_OVERLAY_REMOVAL"):
+        return
+    try:
+        page.evaluate(_REMOVE_AD_OVERLAYS_JS)
+    except Exception:
+        pass
+
+
+def _is_known_provider_url(url: str) -> bool:
+    """Return True when *url* belongs to a known video-provider domain."""
+    try:
+        from urllib.parse import urlparse as _up
+        netloc = _up(url).netloc.lower().lstrip("www.")
+        return any(netloc == p or netloc.endswith("." + p) for p in _KNOWN_PROVIDER_NETLOCS)
+    except Exception:
+        return False
+
+
+def _is_captcha_infra_url(url: str) -> bool:
+    """True for Cloudflare / Turnstile / captcha iframe URLs.
+
+    These must never be mistaken for the provider result: after the modal is
+    submitted the Turnstile iframe (challenges.cloudflare.com/...) is still on
+    the page, and the foreign-iframe detection would otherwise grab it and hand
+    it to the VOE extractor (→ 403, "Keine VOE-Videoquelle gefunden").
+    """
+    u = (url or "").lower()
+    return ("challenges.cloudflare.com" in u
+            or "cdn-cgi/challenge-platform" in u
+            or "/turnstile/" in u
+            or "hcaptcha.com" in u
+            or "recaptcha" in u)
+
+
+# JavaScript injected at document start: a MutationObserver that continuously
+# removes full-page overlay <a> elements, so an ad overlay injected *after* our
+# one-off cleanup still can't hijack a click.
+_AD_OVERLAY_OBSERVER_JS = """
+(() => {
+  const clean = () => {
+    try {
+      document.querySelectorAll('a').forEach(el => {
+        const r  = el.getBoundingClientRect();
+        const cs = window.getComputedStyle(el);
+        const bigEnough  = r.width  > window.innerWidth  * 0.4
+                        && r.height > window.innerHeight * 0.4;
+        const invisible  = parseFloat(cs.opacity) < 0.05
+                        || cs.visibility === 'hidden'
+                        || cs.pointerEvents === 'none';
+        const positioned = cs.position === 'fixed' || cs.position === 'absolute';
+        if (bigEnough && positioned && (invisible || el.getAttribute('target') === '_blank')) {
+          el.remove();
+        }
+      });
+    } catch (e) {}
+  };
+  const start = () => {
+    clean();
+    try {
+      const obs = new MutationObserver(() => clean());
+      obs.observe(document.documentElement || document, {childList: true, subtree: true});
+    } catch (e) {}
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', start);
+  } else {
+    start();
+  }
+})();
+"""
+
+# Third-party hosts that must stay reachable during captcha solving: Cloudflare
+# (Turnstile), common safe CDNs and hCaptcha/reCAPTCHA fallback infrastructure.
+_AD_SAFE_HOST_SUFFIXES = (
+    "cloudflare.com",
+    "cloudflareinsights.com",
+    "jsdelivr.net",
+    "unpkg.com",
+    "googleapis.com",
+    "gstatic.com",
+    "google.com",
+    "hcaptcha.com",
+    "recaptcha.net",
+    "s.to",
+    "serienstream.to",
+    "aniworld.to",
+    "filmpalast.to",
+)
+
+
+def _ad_host_allowed(host: str, home_netloc: str) -> bool:
+    """True when *host* may load during captcha solving (i.e. is not an ad)."""
+    if not host:
+        return True
+    home = home_netloc.lower()
+    if home.startswith("www."):
+        home = home[4:]
+    if host == home or host.endswith("." + home):
+        return True
+    if _is_known_provider_url("https://" + host):
+        return True
+    return any(host == s or host.endswith("." + s) for s in _AD_SAFE_HOST_SUFFIXES)
+
+
+def _install_network_adblock(context, home_netloc: str, weiter_event=None) -> None:
+    """Register a network route handler that aborts requests to third-party (ad)
+    hosts — popunders, ad iframes and their scripts never load. The episode
+    site, Cloudflare Turnstile and known providers stay reachable. Once the
+    Turnstile form has been submitted, third-party navigations/frames are
+    allowed again so the provider result (which may sit on an unpredictable
+    alias domain) can still be captured.
+    """
+    from urllib.parse import urlparse as _up
+
+    def _route(route):
+        try:
+            req = route.request
+            host = _up(req.url).netloc.lower()
+            if host.startswith("www."):
+                host = host[4:]
+            if _ad_host_allowed(host, home_netloc):
+                route.continue_()
+                return
+            rtype = req.resource_type
+            # After submit the provider result may navigate to an unknown alias
+            # domain — allow its top-level navigation / iframe so we can read it.
+            if (weiter_event is not None and weiter_event.is_set()
+                    and rtype in ("document", "sub_frame")):
+                route.continue_()
+                return
+            if rtype in ("document", "sub_frame", "script", "xhr",
+                         "fetch", "media", "websocket"):
+                route.abort()
+                return
+            route.continue_()
+        except Exception:
+            try:
+                route.continue_()
+            except Exception:
+                pass
+
+    try:
+        context.route("**/*", _route)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint hardening
+# ---------------------------------------------------------------------------
+
+# WebGL renderer spoof.  Under Xvfb (Docker) Chromium reports a SwiftShader
+# renderer ("ANGLE (Google, SwiftShader ...)") — one of the strongest bot
+# signals Turnstile evaluates.  This replaces only the UNMASKED vendor/renderer
+# strings with a plausible *Linux* Intel/Mesa GPU, keeping the function looking
+# native.  Enabled by default in Docker only (see _webgl_spoof_enabled); on a
+# real desktop GPU it stays off so we don't fake a worse fingerprint.
+_WEBGL_SPOOF_JS = """
+(() => {
+  const VENDOR   = 'Google Inc. (Intel)';
+  const RENDERER = 'ANGLE (Intel, Mesa Intel(R) UHD Graphics (CML GT2), OpenGL 4.6 (Core Profile) Mesa 23.2.1)';
+  const patch = (proto) => {
+    if (!proto || !proto.getParameter || proto.getParameter.__aniworld) return;
+    const orig = proto.getParameter;
+    const wrapped = function (p) {
+      if (p === 37445) return VENDOR;    // UNMASKED_VENDOR_WEBGL
+      if (p === 37446) return RENDERER;  // UNMASKED_RENDERER_WEBGL
+      return orig.apply(this, arguments);
+    };
+    try {
+      wrapped.toString = orig.toString.bind(orig);
+      Object.defineProperty(wrapped, 'name', {value: 'getParameter', configurable: true});
+    } catch (e) {}
+    wrapped.__aniworld = true;
+    proto.getParameter = wrapped;
+  };
+  try { patch(self.WebGLRenderingContext && WebGLRenderingContext.prototype); } catch (e) {}
+  try { patch(self.WebGL2RenderingContext && WebGL2RenderingContext.prototype); } catch (e) {}
+})();
+"""
+
+
+def _in_docker() -> bool:
+    import os
+    return os.path.exists("/.dockerenv") or os.environ.get("ANIWORLD_DOCKER") == "1"
+
+
+def _webgl_spoof_enabled() -> bool:
+    """WebGL renderer spoof — OFF by default.
+
+    Spoofing only the renderer *string* while the actual rendering stays
+    SwiftShader produces an inconsistent fingerprint: getShaderPrecisionFormat,
+    the MAX_* parameters, the supported extensions and the canvas/WebGL render
+    hash all still report SwiftShader.  Cloudflare is trained on exactly that
+    inconsistency, so a string that says "Intel" on top of SwiftShader is a
+    *stronger* bot signal than an honest SwiftShader string.  Enable only to
+    A/B test with ANIWORLD_SPOOF_WEBGL=1; the real fix is a GPU or Mesa llvmpipe.
+    """
+    import os
+    return os.environ.get("ANIWORLD_SPOOF_WEBGL", "0") == "1"
+
+
+def _persistent_profile_enabled() -> bool:
+    """Persistent Chromium profile.
+
+    Default: ON only inside Docker (a clean, volume-mounted profile keeps
+    cf_clearance warm).  On a real desktop a stale/flagged profile causes
+    *persistent* "verification failed" loops, so a fresh context is used each
+    time.  Force with ANIWORLD_PERSISTENT_PROFILE=1, disable with
+    ANIWORLD_NO_PERSISTENT_PROFILE=1.
+    """
+    import os
+    if os.environ.get("ANIWORLD_NO_PERSISTENT_PROFILE", "0") == "1":
+        return False
+    if os.environ.get("ANIWORLD_PERSISTENT_PROFILE") == "1":
+        return True
+    return _in_docker()
+
+
+_PROFILE_DIR_CACHE = None
+_PROFILE_LOCK = _threading.Lock()
+
+
+def _resolve_profile_dir() -> str:
+    """Directory for the persistent Chromium profile.  Defaults to
+    ~/.aniworld/browser-profile (a mounted volume in the Docker setup, so the
+    fingerprint and cf_clearance survive container restarts)."""
+    global _PROFILE_DIR_CACHE
+    if _PROFILE_DIR_CACHE:
+        return _PROFILE_DIR_CACHE
+    import os
+    import tempfile
+    candidate = os.environ.get("ANIWORLD_BROWSER_PROFILE")
+    if not candidate:
+        try:
+            from ..config import ANIWORLD_CONFIG_DIR
+            candidate = str(ANIWORLD_CONFIG_DIR / "browser-profile")
+        except Exception:
+            candidate = os.path.join(os.path.expanduser("~"), ".aniworld", "browser-profile")
+    try:
+        os.makedirs(candidate, exist_ok=True)
+        _PROFILE_DIR_CACHE = candidate
+    except Exception:
+        _PROFILE_DIR_CACHE = tempfile.mkdtemp(prefix="aniworld-bp-")
+    return _PROFILE_DIR_CACHE
+
+
+def _stealth_context_kwargs() -> dict:
+    kw = dict(ignore_https_errors=True)
+    if _in_docker():
+        # Under Xvfb a headed window renders at full size regardless of its
+        # (off-screen) position, so no_viewport gives a correct render area and
+        # click coordinates that match what Playwright measures.  The container
+        # is otherwise UTC / C-locale, so give it a realistic identity here.
+        kw["no_viewport"] = True
+        kw["locale"] = "de-DE"
+        kw["timezone_id"] = "Europe/Berlin"
+    else:
+        # Real desktop: do NOT force locale/timezone — the machine already has
+        # consistent, real ones, and overriding them can contradict other
+        # signals and trip Cloudflare.  Fixed viewport matching the window so an
+        # off-screen WebUI window still renders (no_viewport would be degenerate
+        # off-screen on Windows).
+        kw["viewport"] = {"width": 1920, "height": 1080}
+    return kw
+
+
+def _stealth_launch_args(offscreen: bool) -> list:
+    # --disable-dev-shm-usage: the default 64 MB /dev/shm in Docker is too small,
+    #   so the Chromium renderer crashes on larger pages — which shows up as a
+    #   captcha that won't render, a blank popup or random scrolling.  Harmless
+    #   outside Docker.
+    args = [
+        "--window-size=1920,1080",
+        "--lang=de-DE,de",
+        "--disable-dev-shm-usage",
+    ]
+    if _in_docker():
+        # Chromium refuses to build its sandbox when running as root in a
+        # capability-stripped container; --no-sandbox is the standard Docker
+        # workaround and is NOT observable from the page (no JS fingerprint).
+        args.append("--no-sandbox")
+    if offscreen:
+        args.insert(0, "--window-position=-32000,-32000")
+    return args
+
+
+def _network_adblock_enabled() -> bool:
+    """Network ad-blocking is on by default; kill-switch via ANIWORLD_NO_ADBLOCK=1
+    (use it to rule the ad-blocker out when the captcha won't load)."""
+    import os
+    return os.environ.get("ANIWORLD_NO_ADBLOCK", "0") != "1"
+
+
+def _env_flag(name: str) -> bool:
+    """True when the given environment variable is set to "1"."""
+    import os
+    return os.environ.get(name, "0") == "1"
+
+
+def _captcha_timeout(default_seconds: int) -> int:
+    """Captcha solve timeout in seconds; overridable via ANIWORLD_CAPTCHA_TIMEOUT
+    (falls back to *default_seconds* when unset or invalid)."""
+    import os
+    raw = os.environ.get("ANIWORLD_CAPTCHA_TIMEOUT", "")
+    try:
+        v = int(raw)
+        return v if v > 0 else default_seconds
+    except (ValueError, TypeError):
+        return default_seconds
+
+
+def _install_stealth(context, ad_home=None, weiter_event=None) -> None:
+    """Install ad + fingerprint defences on a patchright context: continuous
+    overlay removal, optional WebGL spoof, and (when *ad_home* is given) the
+    network ad-blocker."""
+    if not _env_flag("ANIWORLD_CAPTCHA_NO_OVERLAY_REMOVAL"):
+        try:
+            context.add_init_script(_AD_OVERLAY_OBSERVER_JS)
+        except Exception:
+            pass
+    if _webgl_spoof_enabled():
+        try:
+            context.add_init_script(_WEBGL_SPOOF_JS)
+        except Exception:
+            pass
+    if ad_home and _network_adblock_enabled():
+        _install_network_adblock(context, ad_home, weiter_event)
+
+
+def _sync_session_user_agent(page) -> None:
+    """Align GLOBAL_SESSION's User-Agent with the real browser UA.
+
+    cf_clearance is bound to the UA that solved the challenge; if later HTTP
+    requests use a different UA the cookie is rejected.  In Docker the browser is
+    a Linux Chromium while the session UA defaults to a random Windows string —
+    a guaranteed mismatch — so copy the browser UA onto the session.
+    """
+    if _env_flag("ANIWORLD_CAPTCHA_NO_UA_SYNC"):
+        return
+    try:
+        ua = page.evaluate("() => navigator.userAgent")
+    except Exception:
+        return
+    if ua and isinstance(ua, str):
+        try:
+            from ..config import GLOBAL_SESSION
+            GLOBAL_SESSION.headers["User-Agent"] = ua
+        except Exception:
+            pass
+
+
+class _BrowserHandle:
+    """Wraps a patchright context (persistent or ephemeral) + its browser and
+    the profile lock, so callers close everything with one call."""
+
+    def __init__(self, context, browser, got_lock):
+        self.context = context
+        self._browser = browser
+        self._got_lock = got_lock
+
+    def close(self):
+        try:
+            self.context.close()
+        except Exception:
+            pass
+        if self._browser is not None:
+            try:
+                self._browser.close()
+            except Exception:
+                pass
+        if self._got_lock:
+            try:
+                _PROFILE_LOCK.release()
+            except Exception:
+                pass
+
+
+def _launch_browser_context(p, offscreen=False, ad_home=None, weiter_event=None) -> "_BrowserHandle":
+    """Launch a hardened patchright context.
+
+    Prefers a persistent profile (stable fingerprint + warm cf_clearance, which
+    raises the Turnstile trust score).  Only one solve may use the profile at a
+    time; concurrent solves — or any failure to open it — fall back to an
+    ephemeral context, so the worst case equals the previous behaviour.
+    """
+    args = _stealth_launch_args(offscreen)
+    ctx_kwargs = _stealth_context_kwargs()
+    browser = None
+    context = None
+    got_lock = False
+    if _persistent_profile_enabled() and _PROFILE_LOCK.acquire(blocking=False):
+        got_lock = True
+        try:
+            context = p.chromium.launch_persistent_context(
+                _resolve_profile_dir(), headless=False, args=args, **ctx_kwargs
+            )
+        except Exception:
+            context = None
+            try:
+                _PROFILE_LOCK.release()
+            except Exception:
+                pass
+            got_lock = False
+    if context is None:
+        browser = p.chromium.launch(headless=False, args=args)
+        context = browser.new_context(**ctx_kwargs)
+    _install_stealth(context, ad_home=ad_home, weiter_event=weiter_event)
+    return _BrowserHandle(context, browser, got_lock)
 
 
 def _click_turnstile(page, logger=None) -> bool:
@@ -27,47 +518,142 @@ def _click_turnstile(page, logger=None) -> bool:
 
     Uses human-like mouse movement (random offsets + step-based move) so that
     Turnstile does not flag the click as automated.
+
+    Removes invisible full-page ad-overlay elements first so that the mouse
+    events reach the Turnstile iframe and don't accidentally open an ad tab.
+
     Returns True if a click was performed.
     """
-    selectors = (
-        "iframe[src*='challenges.cloudflare.com']",
-        "iframe[src*='cdn-cgi/challenge-platform']",
-    )
-    for selector in selectors:
-        try:
-            iframe_el = page.locator(selector).first
-            iframe_el.wait_for(state="visible", timeout=2500)
-            box = iframe_el.bounding_box()
-            if not box:
+    if _env_flag("ANIWORLD_CAPTCHA_MANUAL"):
+        # Manual mode: never synthesise a click.  Report success so the caller
+        # stops auto-clicking and simply polls for the token that the user's own
+        # click (CLI window / streamed WebUI) will produce.
+        if logger:
+            logger.debug("Captcha manual mode — auto-click skipped, waiting for user")
+        return True
+
+    def _looks_like_turnstile(u):
+        u = (u or "").lower()
+        return ("challenges.cloudflare.com" in u
+                or "cdn-cgi/challenge-platform" in u
+                or "turnstile" in u
+                or "hcaptcha.com" in u)
+
+    # Locate the Turnstile iframe ELEMENT.  It is frequently nested inside
+    # another iframe (the serienstream.to modal / player-iframe), so a
+    # top-level page.locator("iframe[...]") can't see it.  Walking page.frames
+    # finds the challenge frame at any depth; frame.frame_element() returns the
+    # hosting <iframe> whose bounding box is already mapped into top-level page
+    # coords.
+    iframe_el = None
+    try:
+        for fr in page.frames:
+            if _looks_like_turnstile(fr.url):
+                try:
+                    el = fr.frame_element()
+                except Exception:
+                    el = None
+                if el:
+                    iframe_el = el
+                    break
+    except Exception:
+        pass
+
+    # Fallback: top-frame locator (covers the non-nested case).
+    if iframe_el is None:
+        for selector in (
+            "iframe[src*='challenges.cloudflare.com']",
+            "iframe[src*='turnstile']",
+            "iframe[src*='cdn-cgi/challenge-platform']",
+        ):
+            try:
+                loc = page.locator(selector).first
+                loc.wait_for(state="visible", timeout=1500)
+                iframe_el = loc.element_handle()
+                if iframe_el:
+                    break
+            except Exception:
                 continue
 
-            # The checkbox sits on the left side of the widget (~28px in).
-            x = box["x"] + 28 + _random.uniform(-4, 4)
-            y = box["y"] + box["height"] / 2 + _random.uniform(-3, 3)
+    if iframe_el is None:
+        if logger:
+            try:
+                urls = [f.url for f in page.frames]
+            except Exception:
+                urls = []
+            logger.warning("No Turnstile iframe found to click; frames=%s" % urls)
+        return False
 
-            # Move in several steps, pause briefly, then mouse-down/up.
-            page.mouse.move(x, y, steps=_random.randint(8, 20))
-            page.wait_for_timeout(_random.randint(80, 250))
-            page.mouse.down()
-            page.wait_for_timeout(_random.randint(40, 100))
-            page.mouse.up()
-
-            if logger:
-                logger.info("Turnstile checkbox clicked")
-            return True
+    try:
+        try:
+            iframe_el.scroll_into_view_if_needed(timeout=1500)
         except Exception:
-            continue
-    return False
+            pass
+
+        # Let the widget settle, but accept any usable box.
+        box = None
+        for _ in range(8):
+            b = iframe_el.bounding_box()
+            if b and b["width"] > 0 and b["height"] > 0:
+                box = b
+                if b["width"] > 40:   # fully laid out — good to click
+                    break
+            page.wait_for_timeout(150)
+        if not box:
+            if logger:
+                logger.warning("Turnstile iframe found but has no bounding box yet")
+            return False
+
+        _remove_ad_overlays(page)
+
+        # Checkbox sits on the left of the widget, vertically centred.
+        if box["width"] > 40:
+            inset = min(30.0, box["width"] * 0.12)
+        else:
+            inset = box["width"] / 2
+        x = box["x"] + inset + _random.uniform(-2, 2)
+        y = box["y"] + box["height"] / 2 + _random.uniform(-2, 2)
+
+        page.mouse.move(x, y, steps=_random.randint(8, 20))
+        page.wait_for_timeout(_random.randint(80, 220))
+        page.mouse.down()
+        page.wait_for_timeout(_random.randint(40, 100))
+        page.mouse.up()
+
+        if logger:
+            logger.warning(
+                "Turnstile checkbox clicked at (%d,%d) [box %dx%d]"
+                % (int(x), int(y), int(box["width"]), int(box["height"]))
+            )
+        return True
+    except Exception as e:
+        if logger:
+            logger.warning("Turnstile click failed: %s" % e)
+        return False
 
 
 def _is_turnstile_token_ready(page) -> bool:
-    """Check whether the Turnstile hidden input already carries a token."""
+    """Check whether the Turnstile hidden input already carries a token.
+
+    Searches the main document *and* every sub-frame, because serienstream.to
+    renders the Turnstile widget inside a modal that may live in a nested
+    frame.
+    """
+    js = (
+        "() => { const el = document.querySelector"
+        "('input[name=\"cf-turnstile-response\"]');"
+        " return !!(el && el.value && el.value.length > 20); }"
+    )
     try:
-        return page.evaluate(
-            "() => { const el = document.querySelector"
-            "('input[name=\"cf-turnstile-response\"]');"
-            " return !!(el && el.value && el.value.length > 20); }"
-        )
+        if page.evaluate(js):
+            return True
+        for fr in page.frames:
+            try:
+                if fr.evaluate(js):
+                    return True
+            except Exception:
+                continue
+        return False
     except Exception:
         return False
 
@@ -108,7 +694,14 @@ def _neutralize_click_blockers(page) -> None:
 
 
 def _click_submit_button(page, logger=None) -> bool:
-    """Click the modal submit button with robust fallbacks for intercepted clicks."""
+    """Click the modal submit button with robust fallbacks for intercepted clicks.
+
+    Tries a plain click, then a forced click after neutralizing known
+    ad/overlay blockers, then a direct JS click as a last resort. Used instead
+    of a bare ``page.locator(...).click()`` everywhere the Weiter/submit
+    button is pressed, since serienstream.to occasionally layers an
+    (invisible) ad element on top of it.
+    """
     selectors = (
         'button[type="submit"]',
         "button:has-text('Weiter')",
@@ -165,8 +758,361 @@ def _click_submit_button(page, logger=None) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Second-widget support (reCAPTCHA / hCaptcha stacked below Turnstile)
+# ---------------------------------------------------------------------------
+# Some VOE modals ("Video wird vorbereitet...") stack a second checkbox
+# captcha *underneath* the Cloudflare Turnstile widget in the same form.
+# Turns out this second "I'm not a robot ☺" box is NOT real Google reCAPTCHA
+# (the icon is a plain smiley, not the reCAPTCHA robot glyph, and there is no
+# google.com/recaptcha iframe on the page at all) — it's VOE's own fake
+# checkbox: a plain <input type="checkbox"> + label with client-side JS that
+# blocks submit ("Please tick this box if you want to proceed.") until it's
+# ticked. Only Turnstile was being auto-solved, so "Weiter" got clicked while
+# this plain checkbox was still unticked. The helpers below detect *all*
+# checkbox-style challenge widgets present on the page — both real iframe
+# captchas (Turnstile/reCAPTCHA/hCaptcha) and this kind of plain in-page
+# checkbox — click whichever ones aren't solved yet, and only report "ready"
+# once every widget actually present has a token / is checked.
+
+_HUMAN_CHECKBOX_KEYWORDS = ("robot", "roboter", "human", "mensch", "captcha", "bot")
+
+# Scans every checkbox <input> on the page/frame for one whose label/parent
+# text mentions "robot"/"human"/etc. Returns 'checked' | 'unchecked' | null.
+_HUMAN_CHECKBOX_SCAN_JS = """
+(kws) => {
+  const boxes = Array.from(document.querySelectorAll('input[type="checkbox"]'));
+  for (const cb of boxes) {
+    if (cb.disabled) continue;
+    let text = '';
+    if (cb.id) {
+      try {
+        const lbl = document.querySelector(`label[for="${CSS.escape(cb.id)}"]`);
+        if (lbl) text += ' ' + lbl.textContent;
+      } catch (e) {}
+    }
+    const pl = cb.closest('label');
+    if (pl) text += ' ' + pl.textContent;
+    if (cb.parentElement) text += ' ' + cb.parentElement.textContent;
+    text = text.toLowerCase();
+    if (kws.some(k => text.includes(k))) {
+      return cb.checked ? 'checked' : 'unchecked';
+    }
+  }
+  return null;
+}
+"""
+
+# Same scan, but marks the matching unchecked box with a data attribute so
+# Playwright can locate + click it as a real element (native click, not a
+# simulated mouse-move — it's a normal form control, not an iframe overlay).
+_HUMAN_CHECKBOX_MARK_JS = """
+(kws) => {
+  const boxes = Array.from(document.querySelectorAll('input[type="checkbox"]'));
+  for (const cb of boxes) {
+    if (cb.checked || cb.disabled) continue;
+    let text = '';
+    if (cb.id) {
+      try {
+        const lbl = document.querySelector(`label[for="${CSS.escape(cb.id)}"]`);
+        if (lbl) text += ' ' + lbl.textContent;
+      } catch (e) {}
+    }
+    const pl = cb.closest('label');
+    if (pl) text += ' ' + pl.textContent;
+    if (cb.parentElement) text += ' ' + cb.parentElement.textContent;
+    text = text.toLowerCase();
+    if (kws.some(k => text.includes(k))) {
+      cb.setAttribute('data-aw-human-cb', '1');
+      return true;
+    }
+  }
+  return false;
+}
+"""
+
+
+def _human_checkbox_state(page):
+    """Return 'checked' / 'unchecked' if a plain "I'm not a robot"-style
+    checkbox is found anywhere on the page (main document or any frame),
+    else None."""
+    for ctx in [page] + list(page.frames):
+        try:
+            r = ctx.evaluate(_HUMAN_CHECKBOX_SCAN_JS, list(_HUMAN_CHECKBOX_KEYWORDS))
+        except Exception:
+            r = None
+        if r:
+            return r
+    return None
+
+
+def _click_human_checkbox(page, logger=None) -> bool:
+    """Find and click a plain (non-iframe) "I'm not a robot"-style checkbox."""
+    if _env_flag("ANIWORLD_CAPTCHA_MANUAL"):
+        if logger:
+            logger.debug("Captcha manual mode — auto-click skipped (checkbox)")
+        return True
+    for ctx in [page] + list(page.frames):
+        try:
+            found = ctx.evaluate(_HUMAN_CHECKBOX_MARK_JS, list(_HUMAN_CHECKBOX_KEYWORDS))
+        except Exception:
+            found = False
+        if not found:
+            continue
+        try:
+            loc = ctx.locator('[data-aw-human-cb="1"]').first
+            loc.wait_for(state="attached", timeout=1000)
+            loc.scroll_into_view_if_needed(timeout=1500)
+            loc.click(timeout=2000)
+            if logger:
+                logger.warning("Clicked plain 'not a robot' checkbox")
+            return True
+        except Exception as e:
+            if logger:
+                logger.warning(f"Human-checkbox click failed: {e}")
+            return False
+    return False
+
+
+_CHALLENGE_IFRAME_SELECTORS = {
+    "turnstile": (
+        "iframe[src*='challenges.cloudflare.com']",
+        "iframe[src*='turnstile']",
+        "iframe[src*='cdn-cgi/challenge-platform']",
+    ),
+    "recaptcha": (
+        "iframe[src*='google.com/recaptcha']",
+        "iframe[src*='recaptcha.net']",
+    ),
+    "hcaptcha": (
+        "iframe[src*='hcaptcha.com']",
+    ),
+}
+
+_TOKEN_READY_JS = {
+    "turnstile": (
+        "() => { const el = document.querySelector"
+        "('input[name=\"cf-turnstile-response\"]');"
+        " return !!(el && el.value && el.value.length > 20); }"
+    ),
+    "recaptcha": (
+        "() => { const el = document.querySelector"
+        "('#g-recaptcha-response, textarea[name=\"g-recaptcha-response\"]');"
+        " return !!(el && el.value && el.value.length > 20); }"
+    ),
+    "hcaptcha": (
+        "() => { const el = document.querySelector"
+        "('textarea[name=\"h-captcha-response\"]');"
+        " return !!(el && el.value && el.value.length > 20); }"
+    ),
+}
+
+
+def _looks_like_challenge_iframe(u: str, kind: str) -> bool:
+    u = (u or "").lower()
+    if kind == "turnstile":
+        return ("challenges.cloudflare.com" in u
+                or "cdn-cgi/challenge-platform" in u
+                or "turnstile" in u)
+    if kind == "recaptcha":
+        return "google.com/recaptcha" in u or "recaptcha.net" in u
+    if kind == "hcaptcha":
+        return "hcaptcha.com" in u
+    return False
+
+
+def _present_challenge_kinds(page) -> set:
+    """Which challenge kinds currently need attention on the page: the iframe
+    captchas ('turnstile' / 'recaptcha' / 'hcaptcha') plus 'checkbox' for a
+    plain in-page "I'm not a robot" checkbox (VOE's fake-captcha pattern). A
+    modal can show more than one at once (e.g. Turnstile + a plain checkbox
+    stacked below it), so this returns a set."""
+    kinds = set()
+    try:
+        for fr in page.frames:
+            for kind in ("turnstile", "recaptcha", "hcaptcha"):
+                if kind not in kinds and _looks_like_challenge_iframe(fr.url, kind):
+                    kinds.add(kind)
+    except Exception:
+        pass
+    if _human_checkbox_state(page) is not None:
+        kinds.add("checkbox")
+    return kinds
+
+
+def _is_challenge_token_ready(page, kind: str) -> bool:
+    """Like _is_turnstile_token_ready(), generalised to reCAPTCHA/hCaptcha and
+    to the plain 'checkbox' kind (ready == the box is ticked)."""
+    if kind == "checkbox":
+        return _human_checkbox_state(page) == "checked"
+    js = _TOKEN_READY_JS.get(kind)
+    if not js:
+        return False
+    try:
+        if page.evaluate(js):
+            return True
+        for fr in page.frames:
+            try:
+                if fr.evaluate(js):
+                    return True
+            except Exception:
+                continue
+        return False
+    except Exception:
+        return False
+
+
+def _click_challenge_checkbox(page, kind: str, logger=None) -> bool:
+    """Locate a checkbox-captcha iframe of *kind* and click it.
+
+    Same human-like-mouse-move approach as _click_turnstile(), generalised so
+    it also works for reCAPTCHA's / hCaptcha's checkbox iframe. The plain
+    'checkbox' kind (no iframe involved) is delegated to
+    _click_human_checkbox().
+    """
+    if kind == "checkbox":
+        return _click_human_checkbox(page, logger)
+
+    if _env_flag("ANIWORLD_CAPTCHA_MANUAL"):
+        if logger:
+            logger.debug(f"Captcha manual mode — auto-click skipped ({kind})")
+        return True
+
+    iframe_el = None
+    try:
+        for fr in page.frames:
+            if _looks_like_challenge_iframe(fr.url, kind):
+                try:
+                    el = fr.frame_element()
+                except Exception:
+                    el = None
+                if el:
+                    iframe_el = el
+                    break
+    except Exception:
+        pass
+
+    if iframe_el is None:
+        for selector in _CHALLENGE_IFRAME_SELECTORS.get(kind, ()):
+            try:
+                loc = page.locator(selector).first
+                loc.wait_for(state="visible", timeout=1500)
+                iframe_el = loc.element_handle()
+                if iframe_el:
+                    break
+            except Exception:
+                continue
+
+    if iframe_el is None:
+        if logger:
+            logger.debug(f"No {kind} iframe found to click")
+        return False
+
+    try:
+        try:
+            iframe_el.scroll_into_view_if_needed(timeout=1500)
+        except Exception:
+            pass
+
+        box = None
+        for _ in range(8):
+            b = iframe_el.bounding_box()
+            if b and b["width"] > 0 and b["height"] > 0:
+                box = b
+                if b["width"] > 40:
+                    break
+            page.wait_for_timeout(150)
+        if not box:
+            if logger:
+                logger.warning(f"{kind} iframe found but has no bounding box yet")
+            return False
+
+        _remove_ad_overlays(page)
+
+        if box["width"] > 40:
+            inset = min(30.0, box["width"] * 0.12)
+        else:
+            inset = box["width"] / 2
+        x = box["x"] + inset + _random.uniform(-2, 2)
+        y = box["y"] + box["height"] / 2 + _random.uniform(-2, 2)
+
+        page.mouse.move(x, y, steps=_random.randint(8, 20))
+        page.wait_for_timeout(_random.randint(80, 220))
+        page.mouse.down()
+        page.wait_for_timeout(_random.randint(40, 100))
+        page.mouse.up()
+
+        if logger:
+            logger.warning(
+                f"{kind} checkbox clicked at (%d,%d) [box %dx%d]"
+                % (int(x), int(y), int(box["width"]), int(box["height"]))
+            )
+        return True
+    except Exception as e:
+        if logger:
+            logger.warning(f"{kind} click failed: {e}")
+        return False
+
+
+class _ChallengeSolver:
+    """Drives *all* checkbox-captcha widgets present in a modal (not just
+    Turnstile) across a polling loop.
+
+    Clicks each unsolved widget (with an 8s grace period before re-clicking
+    one that still has no token — a checkbox mid-validation resets if
+    clicked again), and reports "ready" only once every widget currently on
+    the page has a token, so the caller doesn't submit the form while a
+    second, stacked captcha (e.g. a reCAPTCHA "I'm not a robot" box under
+    Turnstile) is still unticked.
+    """
+
+    def __init__(self):
+        self._clicked = {}
+        self._last_click = {}
+
+    def ready_to_submit(self, page, logger=None) -> bool:
+        kinds = _present_challenge_kinds(page)
+        if not kinds:
+            return False
+        all_ready = True
+        for kind in kinds:
+            if _is_challenge_token_ready(page, kind):
+                continue
+            all_ready = False
+            now = _time.time()
+            if not self._clicked.get(kind):
+                if _click_challenge_checkbox(page, kind, logger):
+                    self._clicked[kind] = True
+                    self._last_click[kind] = now
+                    page.wait_for_timeout(_random.randint(1500, 2500))
+            elif now - self._last_click.get(kind, 0) > 8:
+                self._clicked[kind] = False
+        return all_ready
+
+
+def _is_captcha_page_dom(page) -> bool:
+    """Lightweight DOM query to detect an active CF challenge — avoids full page.content() serialization."""
+    try:
+        return page.evaluate(
+            """() => {
+              const t = (document.title || '').toLowerCase();
+              if (t.includes('just a moment') || t.includes('attention required')) return true;
+              return !!document.querySelector(
+                '#challenge-running, #cf-challenge-running, .cf-turnstile,'
+                + ' [class*="challenge-"], [id*="challenge-"]'
+              );
+            }"""
+        )
+    except Exception:
+        return True  # assume still on captcha page if evaluation fails
+
+
 def is_captcha_page(html: str, status_code: int = 200) -> bool:
-    """Detect Cloudflare challenge / CAPTCHA pages."""
+    """Detect Cloudflare challenge / CAPTCHA pages.
+
+    Used by: aniworld.extractors.provider.voe, to decide when to fall back
+    to solve_captcha().
+    """
     if status_code in (403, 503):
         return True
 
@@ -215,6 +1161,9 @@ def solve_captcha(url: str):
     Returns the final URL (str) on success — for redirect-based captchas this is
     the provider URL captured from an iframe.  Returns None on timeout / error.
     Callers that don't need the URL can ignore the return value.
+
+    Used by: aniworld.extractors.provider.voe, after is_captcha_page()
+    detects a Cloudflare challenge on a VOE response.
     """
     queue_id = getattr(_local, "queue_id", None)
     if queue_id is not None:
@@ -234,7 +1183,6 @@ def _solve_captcha_cli(url: str) -> bool:
 
     from ..config import GLOBAL_SESSION
     from ..logger import get_logger
-
     logger = get_logger(__name__)
 
     with _captcha_lock:
@@ -242,24 +1190,21 @@ def _solve_captcha_cli(url: str) -> bool:
         with _captcha_state_lock:
             _captcha_state = {"url": url, "started_at": _time.time(), "solved": False}
 
-        logger.warning(
-            f"CAPTCHA detected for {url} — opening browser for manual solving"
-        )
+        logger.warning(f"CAPTCHA detected for {url} — opening browser for manual solving")
 
         try:
             from ..autodeps import _ensure_xvfb
-
             _ensure_xvfb()
             with sync_playwright() as p:
                 browser = p.chromium.launch(headless=False)
-                context = browser.new_context()
+                context = browser.new_context(ignore_https_errors=True)
                 page = context.new_page()
                 page.goto(url, wait_until="domcontentloaded")
 
-                timeout = 300  # 5 minutes
+                timeout = _captcha_timeout(300)  # default 5 minutes
                 start = _time.time()
                 solved = False
-                turnstile_clicked = False
+                challenge_solver = _ChallengeSolver()
 
                 while _time.time() - start < timeout:
                     # Standard Cloudflare full-page challenge
@@ -267,9 +1212,10 @@ def _solve_captcha_cli(url: str) -> bool:
                         solved = True
                         break
 
-                    # serienstream.to modal: form target="player-iframe" — after Weiter the VOE URL
-                    # loads into that iframe. The modal HTML stays on the page, so
-                    # is_captcha_page() would never become False. Instead poll the frame.
+                    # serienstream.to modal: form target="player-iframe" — after
+                    # Weiter the VOE URL loads into that iframe. The modal HTML
+                    # stays on the page, so is_captcha_page() would never
+                    # become False. Instead poll the frame.
                     for frame in page.frames:
                         if frame.name == "player-iframe":
                             fu = frame.url
@@ -280,26 +1226,15 @@ def _solve_captcha_cli(url: str) -> bool:
                     if solved:
                         break
 
-                    # Also check page content for classic full-page solve
-                    try:
-                        if not is_captcha_page(page.content()):
-                            solved = True
-                            break
-                    except Exception:
-                        pass
+                    # Check for classic full-page solve using lightweight DOM query
+                    if not _is_captcha_page_dom(page):
+                        solved = True
+                        break
 
-                    # Click Turnstile checkbox if not yet clicked
-                    if not turnstile_clicked and not _is_turnstile_token_ready(page):
-                        if _click_turnstile(page, logger):
-                            turnstile_clicked = True
-                            page.wait_for_timeout(_random.randint(2000, 4000))
-                            continue
-                    elif turnstile_clicked and not _is_turnstile_token_ready(page):
-                        # Turnstile may have reset — allow re-click
-                        turnstile_clicked = False
-
-                    # Auto-click Weiter once Turnstile token is present
-                    if _is_turnstile_token_ready(page):
+                    # Click any unsolved captcha checkbox (Turnstile, plus a
+                    # second stacked reCAPTCHA/hCaptcha widget if present) and
+                    # only submit once every widget on the page has a token.
+                    if challenge_solver.ready_to_submit(page, logger):
                         try:
                             if _click_submit_button(page, logger):
                                 page.wait_for_timeout(2000)
@@ -344,14 +1279,24 @@ class CaptchaSession:
         self.result_url = None
 
     def get_screenshot(self) -> bytes:
+        """Return the most recent JPEG screenshot of the solving browser.
+
+        Used by: aniworld.web.app (streams this to the Web UI).
+        """
         with self._screenshot_lock:
             return self._screenshot
 
     def _store_screenshot(self, data: bytes):
+        """Store the latest screenshot (called from the solve loop)."""
         with self._screenshot_lock:
             self._screenshot = data
 
     def enqueue_click(self, x: int, y: int):
+        """Queue a user click (page coordinates) to be replayed on the page.
+
+        Used by: aniworld.web.app, forwarding clicks the user makes on the
+        streamed screenshot in the Web UI.
+        """
         self._click_queue.put_nowait((x, y))
 
 
@@ -367,7 +1312,6 @@ def _solve_captcha_interactive(url: str, queue_id: int) -> bool:
 
     from ..config import GLOBAL_SESSION
     from ..logger import get_logger
-
     logger = get_logger(__name__)
 
     session = CaptchaSession()
@@ -383,18 +1327,18 @@ def _solve_captcha_interactive(url: str, queue_id: int) -> bool:
     global _captcha_state
     try:
         from ..autodeps import _ensure_xvfb
-
         _ensure_xvfb()
         with sync_playwright() as p:
             # headless=False required for Cloudflare/Turnstile to work.
             # Window pushed off-screen to avoid visible popup on server desktops.
-            browser = p.chromium.launch(
-                headless=False,
-                args=["--window-position=-32000,-32000", "--window-size=1280,720"],
-            )
-            context = browser.new_context(viewport={"width": 1280, "height": 720})
+            # Hardened context: persistent profile, realistic locale/timezone/
+            # viewport, overlay + WebGL defences.  No network ad-block here — this
+            # generic solver must let foreign provider iframes load.
+            _handle = _launch_browser_context(p, offscreen=not _env_flag("ANIWORLD_CAPTCHA_VISIBLE"))
+            context = _handle.context
             page = context.new_page()
             page.goto(url)
+            _sync_session_user_agent(page)
 
             with _captcha_state_lock:
                 _captcha_state = {
@@ -404,8 +1348,8 @@ def _solve_captcha_interactive(url: str, queue_id: int) -> bool:
                 }
 
             solved = False
-            turnstile_clicked = False
-            for _ in range(300):  # up to ~5 minutes
+            challenge_solver = _ChallengeSolver()
+            for _ in range(_captcha_timeout(300)):  # ~1s per iteration
                 # Stream screenshot to Web UI
                 try:
                     shot = page.screenshot(type="jpeg", quality=65)
@@ -438,25 +1382,15 @@ def _solve_captcha_interactive(url: str, queue_id: int) -> bool:
                 if solved:
                     break
 
-                # Classic full-page solve (no modal)
-                try:
-                    if not is_captcha_page(page.content()):
-                        solved = True
-                        break
-                except Exception:
-                    pass
+                # Classic full-page solve (no modal) — lightweight DOM query
+                if not _is_captcha_page_dom(page):
+                    solved = True
+                    break
 
-                # Click Turnstile checkbox if not yet clicked
-                if not turnstile_clicked and not _is_turnstile_token_ready(page):
-                    if _click_turnstile(page):
-                        turnstile_clicked = True
-                        page.wait_for_timeout(_random.randint(2000, 4000))
-                        continue
-                elif turnstile_clicked and not _is_turnstile_token_ready(page):
-                    turnstile_clicked = False
-
-                # Auto-click Weiter button once Turnstile token is present
-                if _is_turnstile_token_ready(page):
+                # Click any unsolved captcha checkbox (Turnstile, plus a
+                # second stacked reCAPTCHA/hCaptcha widget if present) and
+                # only submit once every widget on the page has a token.
+                if challenge_solver.ready_to_submit(page, logger):
                     try:
                         if _click_submit_button(page, logger):
                             page.wait_for_timeout(2000)
@@ -485,7 +1419,7 @@ def _solve_captcha_interactive(url: str, queue_id: int) -> bool:
 
             final_url = page.url
             page.wait_for_timeout(400)
-            browser.close()
+            _handle.close()
 
         # Use the player-iframe URL if captured, otherwise fall back to page URL
         result_url = locals().get("result_url") or _extract_iframe_url(page, url)
@@ -518,7 +1452,6 @@ def _extract_iframe_url(page, current_url: str) -> str:
     """
     try:
         from urllib.parse import urlparse
-
         current_netloc = urlparse(current_url).netloc.lstrip("www.")
         for frame in page.frames:
             u = frame.url
@@ -533,10 +1466,27 @@ def _extract_iframe_url(page, current_url: str) -> str:
 
 
 def playwright_get_page_url(url: str) -> str:
+    """Solve any CAPTCHA on *url*, then return the final resolved URL for it
+    (following redirects) using the shared GLOBAL_SESSION."""
     solve_captcha(url)
     from ..config import GLOBAL_SESSION
-
     return GLOBAL_SESSION.get(url).url
+
+
+def _inject_session_cookies(context, url: str) -> None:
+    """Copy GLOBAL_SESSION cookies into a patchright browser context."""
+    try:
+        from urllib.parse import urlparse
+        from ..config import GLOBAL_SESSION
+        base = f"{urlparse(url).scheme}://{urlparse(url).netloc}"
+        cookies = [
+            {"name": c.name, "value": c.value, "url": base}
+            for c in GLOBAL_SESSION.cookies
+        ]
+        if cookies:
+            context.add_cookies(cookies)
+    except Exception:
+        pass
 
 
 def playwright_get_iframe_url(url: str, timeout: int = 20) -> str:
@@ -721,30 +1671,21 @@ def playwright_get_cineby_stream_url(url: str, timeout: int = 40) -> str:
         return None
 
 
-def _inject_session_cookies(context, url: str) -> None:
-    """Copy GLOBAL_SESSION cookies into a patchright browser context."""
-    try:
-        from urllib.parse import urlparse
-
-        from ..config import GLOBAL_SESSION
-
-        base = f"{urlparse(url).scheme}://{urlparse(url).netloc}"
-        cookies = [
-            {"name": c.name, "value": c.value, "url": base}
-            for c in GLOBAL_SESSION.cookies
-        ]
-        if cookies:
-            context.add_cookies(cookies)
-    except Exception:
-        pass
-
-
-def solve_sto_modal(episode_url: str, provider_name: str, language_label: str):
+def solve_sto_modal(episode_url: str, provider_name: str, language_label: str,
+                    redirect_url: str = None):
     """
-    Open the serienstream.to episode page in a browser, click the provider button,
-    solve the Turnstile modal, click Weiter, and return the player-iframe
-    URL (e.g. voe.sx/e/...).  Works in CLI and WebUI mode.
-    Returns the iframe URL on success, None on timeout.
+    Navigate to the provider redirect URL (or fall back to the episode page),
+    solve any Turnstile modal that appears, and return the player-iframe URL
+    (e.g. voe.sx/e/...).  Works in CLI and WebUI mode.
+
+    redirect_url — the provider-specific /r?t=... link; when supplied the
+    browser navigates there directly so the Turnstile modal is triggered
+    immediately without needing to click a provider button first.
+
+    Returns the provider URL on success, None on timeout.
+
+    Used by: aniworld.models.s_to.episode.SerienstreamEpisode, to resolve
+    the player-iframe URL for an episode's chosen provider.
     """
     try:
         from patchright.sync_api import sync_playwright
@@ -756,7 +1697,6 @@ def solve_sto_modal(episode_url: str, provider_name: str, language_label: str):
 
     from ..config import GLOBAL_SESSION
     from ..logger import get_logger
-
     logger = get_logger(__name__)
 
     queue_id = getattr(_local, "queue_id", None)
@@ -773,17 +1713,35 @@ def solve_sto_modal(episode_url: str, provider_name: str, language_label: str):
 
     global _captcha_state
     try:
-        extra_args = (
-            ["--window-position=-32000,-32000", "--window-size=1280,720"]
-            if queue_id is not None
-            else []
-        )
+        from ..autodeps import _ensure_xvfb
+        _ensure_xvfb()
+
+        # The Turnstile captcha modal lives on the episode page itself. It is
+        # shown by the in-page player JS when the provider's play button (the
+        # element carrying the matching data-play-url) is clicked. Navigating
+        # to the /r?t=... redirect URL directly bounces to the site's
+        # homepage, because the token is consumed by the in-page player JS
+        # and not by a top-level GET — so we open the episode page and click.
+        start_url = episode_url
 
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=False, args=extra_args)
-            context = browser.new_context(
-                viewport={"width": 1280, "height": 720},
+            from urllib.parse import urlparse as _urlparse
+            # Episode-page netloc — the "home" domain.  Any other netloc is
+            # either an ad (blocked) or the provider result (allowed post-submit).
+            sto_netloc = _urlparse(episode_url).netloc
+
+            # Created before the context so the ad-blocker can read it:
+            # navigations after submit are the provider result, not ads.
+            _weiter_submitted = _threading.Event()   # set when submit is clicked
+
+            # Hardened, ad-blocked context: persistent profile, realistic
+            # locale/timezone/viewport, overlay + WebGL fingerprint defences.
+            _handle = _launch_browser_context(
+                p, offscreen=(queue_id is not None) and not _env_flag("ANIWORLD_CAPTCHA_VISIBLE"),
+                ad_home=sto_netloc, weiter_event=_weiter_submitted,
             )
+            context = _handle.context
+
             _inject_session_cookies(context, episode_url)
             page = context.new_page()
 
@@ -794,25 +1752,113 @@ def solve_sto_modal(episode_url: str, provider_name: str, language_label: str):
                     "solved": False,
                 }
 
-            logger.warning(f"Opening episode page for modal solving: {episode_url}")
-            page.goto(episode_url, wait_until="domcontentloaded")
+            # New-tab guard: the site has invisible full-page <a target="_blank">
+            # ad overlays that open an ad tab on any click.
+            #
+            # Strategy: use *timing* rather than a domain whitelist.
+            # - A tab that opens BEFORE the Weiter/submit button is clicked is
+            #   an ad (overlay click during Turnstile mouse movement) → close it.
+            # - A tab that opens AFTER Weiter is clicked is the provider result
+            #   (the site opened it as the player) → keep it, regardless of domain.
+            #   This correctly handles VOE alias domains like jeanprofessorcentral.com
+            #   that we can't predict in advance.
+            # - As a fallback, tabs on known provider domains are always kept even
+            #   if they somehow open before Weiter.
+            _ad_tab_lock = _threading.Lock()
+            _provider_tab_urls: list = []
 
-            # Single poll loop: streams screenshots from the start, clicks
-            # Turnstile checkbox, clicks Weiter once, then waits for result.
-            from urllib.parse import urlparse as _urlparse
+            def _on_new_page(new_pg):
+                try:
+                    new_pg.wait_for_load_state("commit", timeout=4000)
+                    pu = new_pg.url
+                    if not pu or pu in ("about:blank", ""):
+                        return
+                    from urllib.parse import urlparse as _up2
+                    if _up2(pu).netloc == sto_netloc:
+                        return  # still on the episode site — not a provider result
+                    # Keep if: Weiter was already submitted, OR it's a known provider
+                    if _weiter_submitted.is_set() or _is_known_provider_url(pu):
+                        with _ad_tab_lock:
+                            _provider_tab_urls.append(pu)
+                    else:
+                        # Ad tab from overlay click — close immediately, unless
+                        # the ad-tab guard has been disabled.
+                        if not _env_flag("ANIWORLD_CAPTCHA_NO_ADTAB_GUARD"):
+                            try:
+                                new_pg.close()
+                            except Exception:
+                                pass
+                except Exception:
+                    try:
+                        new_pg.close()
+                    except Exception:
+                        pass
+
+            context.on("page", _on_new_page)
+
+            logger.debug(f"Opening episode page for modal solving: {start_url}")
+            page.goto(start_url, wait_until="domcontentloaded")
+            _sync_session_user_agent(page)
+
+            # The captcha modal is triggered by clicking the provider's play
+            # button on the episode page.  Derive the data-play-url value from
+            # the redirect URL (it is exactly the path+query of /r?t=...) and
+            # click the matching element via JS so invisible ad overlays can't
+            # intercept the click.
+            _remove_ad_overlays(page)
+
+            play_path = None
+            if redirect_url:
+                _sp = _urlparse(redirect_url)
+                play_path = _sp.path + (("?" + _sp.query) if _sp.query else "")
+
+            clicked = False
+            if play_path:
+                try:
+                    clicked = page.evaluate(
+                        """(playPath) => {
+                            const els = document.querySelectorAll('[data-play-url]');
+                            for (const el of els) {
+                                if (el.getAttribute('data-play-url') === playPath) {
+                                    el.scrollIntoView({block: 'center'});
+                                    el.click();
+                                    return true;
+                                }
+                            }
+                            return false;
+                        }""",
+                        play_path,
+                    )
+                except Exception as _e:
+                    logger.debug(f"Provider-button click failed: {_e}")
+
+            if clicked:
+                logger.debug(
+                    f"Clicked provider button ({play_path}) — waiting for Turnstile modal"
+                )
+                page.wait_for_timeout(1500)
+                _remove_ad_overlays(page)
+            else:
+                # Fallback (legacy behaviour): the matching play button was not
+                # found on the episode page — navigate to the redirect URL
+                # directly and hope the modal appears there.
+                logger.warning(
+                    "Provider play button not found on episode page — "
+                    "falling back to direct redirect navigation"
+                )
+                if redirect_url:
+                    page.goto(redirect_url, wait_until="domcontentloaded")
 
             final_url = None
             weiter_clicked = False
-            turnstile_clicked = False
+            challenge_solver = _ChallengeSolver()
             start = _time.time()
 
-            while _time.time() - start < 90:
+            while _time.time() - start < _captcha_timeout(90):
                 # WebUI: stream screenshots + forward user clicks
                 if session_obj is not None:
                     try:
-                        session_obj._store_screenshot(
-                            page.screenshot(type="jpeg", quality=65)
-                        )
+                        session_obj._store_screenshot(page.screenshot(type="jpeg", quality=65))
                     except Exception:
                         pass
                     while not session_obj._click_queue.empty():
@@ -823,55 +1869,103 @@ def solve_sto_modal(episode_url: str, provider_name: str, language_label: str):
                         except Exception:
                             pass
 
-                if not weiter_clicked:
-                    token_ready = _is_turnstile_token_ready(page)
+                # ── Provider-URL detection (runs every iteration) ────────────
+                # This must run before the Turnstile logic so that a successful
+                # cookie-based redirect (no Turnstile at all) is captured
+                # immediately without waiting for the timeout.
 
-                    # Click Turnstile checkbox if token not yet filled
-                    if not token_ready and not turnstile_clicked:
-                        if _click_turnstile(page, logger):
-                            turnstile_clicked = True
-                            page.wait_for_timeout(_random.randint(2000, 4000))
+                # 1. player-iframe by name (classic site behaviour).
+                #    IMPORTANT: the form POST to /r first loads an intermediate
+                #    redirect page into the iframe before the final provider
+                #    URL arrives.  We must skip any URL still on sto_netloc so
+                #    we don't hand a serienstream.to URL to the VOE extractor.
+                for frame in page.frames:
+                    if frame.name == "player-iframe":
+                        fu = frame.url
+                        if fu and fu not in ("about:blank", ""):
+                            if (_urlparse(fu).netloc not in ("", sto_netloc)
+                                    and not _is_captcha_infra_url(fu)):
+                                final_url = fu
+                                break
+                if final_url:
+                    logger.debug(f"player-iframe URL found: {final_url}")
+                    break
+
+                # 2. Any iframe whose netloc differs from the episode site —
+                #    only trusted AFTER the Turnstile modal was submitted.
+                #    Before that, the episode page is full of third-party ad
+                #    iframes whose netloc differs from it; without this gate
+                #    the solver would grab an ad iframe, set final_url and
+                #    close the browser immediately (captcha never solved).
+                #    Known provider domains are always accepted as a safety net.
+                if not final_url:
+                    for frame in page.frames:
+                        fu = frame.url
+                        if not fu or fu in ("about:blank", "", start_url, episode_url):
                             continue
-                    elif not token_ready and turnstile_clicked:
-                        # Turnstile may have reset — allow re-click
-                        turnstile_clicked = False
+                        if _urlparse(fu).netloc in ("", sto_netloc):
+                            continue
+                        if _is_captcha_infra_url(fu):
+                            continue  # Turnstile widget, not the provider
+                        if weiter_clicked or _is_known_provider_url(fu):
+                            final_url = fu
+                            logger.warning(f"Foreign iframe URL found: {final_url}")
+                            break
+                if final_url:
+                    break
 
-                    if token_ready:
+                # 3. Main page navigated to a different domain (direct redirect).
+                #    Only trusted after submit / for known providers, so an ad
+                #    that hijacks the top frame can't end the solve early.
+                if not final_url:
+                    try:
+                        pu = page.url
+                        if (pu and _urlparse(pu).netloc not in ("", sto_netloc)
+                                and not _is_captcha_infra_url(pu)):
+                            if weiter_clicked or _is_known_provider_url(pu):
+                                final_url = pu
+                                logger.warning(f"Page navigated to provider: {final_url}")
+                    except Exception:
+                        pass
+                if final_url:
+                    break
+
+                # 4. New tab opened by the site — only accept known provider
+                #    domains. Non-provider tabs (ads) are closed by the context
+                #    handler above; here we just check if any provider tab was
+                #    captured.
+                with _ad_tab_lock:
+                    for _u in reversed(_provider_tab_urls):
+                        if not _is_captcha_infra_url(_u):
+                            final_url = _u
+                            break
+                if final_url:
+                    logger.debug(f"Provider tab URL found: {final_url}")
+                    break
+
+                # ── Captcha solving ──────────────────────────────────────────
+                # Clicks every checkbox-style widget present in the modal —
+                # not just Turnstile.  VOE's "Video wird vorbereitet..." modal
+                # sometimes stacks a second widget (Google reCAPTCHA v2's
+                # "I'm not a robot" checkbox) directly underneath Turnstile;
+                # submitting while it's still unticked gets the form rejected
+                # ("Please tick this box if you want to proceed."), so Weiter
+                # is only clicked once *every* widget on the page has a token.
+                if not weiter_clicked:
+                    if challenge_solver.ready_to_submit(page, logger):
                         try:
+                            # Remove ad overlays before clicking Weiter so the
+                            # submit button click isn't hijacked by the overlay.
+                            _remove_ad_overlays(page)
+                            # Signal BEFORE the click so the new-tab handler
+                            # never races ahead of the flag being set.
+                            _weiter_submitted.set()
                             if _click_submit_button(page, logger):
-                                logger.warning("Submit clicked (Turnstile solved)")
+                                logger.warning("Submit clicked (all captcha tokens ready)")
                                 weiter_clicked = True
-                            else:
-                                logger.warning("Submit click failed (will retry)")
                             page.wait_for_timeout(1200)
                         except Exception as e:
                             logger.warning(f"Submit button error: {e}")
-                else:
-                    # Weiter was clicked – poll for the VOE URL
-                    for frame in page.frames:
-                        if frame.name == "player-iframe":
-                            fu = frame.url
-                            if fu and fu not in ("about:blank", ""):
-                                final_url = fu
-                                break
-                    if final_url:
-                        logger.warning(f"player-iframe URL found: {final_url}")
-                        break
-
-                    # Also check if a new tab was opened
-                    for pg in context.pages:
-                        if pg is not page:
-                            pu = pg.url
-                            if pu and pu not in ("about:blank", ""):
-                                if (
-                                    _urlparse(pu).netloc
-                                    != _urlparse(episode_url).netloc
-                                ):
-                                    final_url = pu
-                                    break
-                    if final_url:
-                        logger.warning(f"New page URL found: {final_url}")
-                        break
 
                 _time.sleep(0.8)
 
@@ -885,13 +1979,11 @@ def solve_sto_modal(episode_url: str, provider_name: str, language_label: str):
 
             if session_obj is not None:
                 try:
-                    session_obj._store_screenshot(
-                        page.screenshot(type="jpeg", quality=65)
-                    )
+                    session_obj._store_screenshot(page.screenshot(type="jpeg", quality=65))
                 except Exception:
                     pass
 
-            browser.close()
+            _handle.close()
 
         with _captcha_state_lock:
             _captcha_state = None
@@ -904,7 +1996,6 @@ def solve_sto_modal(episode_url: str, provider_name: str, language_label: str):
 
     except Exception as e:
         from ..logger import get_logger
-
         get_logger(__name__).error(f"Fehler in solve_sto_modal: {e}", exc_info=True)
         with _captcha_state_lock:
             _captcha_state = None


### PR DESCRIPTION
## Summary
Brings the improved captcha solver from [MediaForge](https://github.com/PD-Codes/MediaForge) (PD-Codes) into `aniworld.playwright.captcha` — significantly more robust detection and fingerprint hardening against Cloudflare Turnstile, without breaking existing AniWorld-Downloader functionality (hanime/cineby stream sniffing).

## What changed
- **Detection:** now solves reCAPTCHA/hCaptcha widgets and s.to's hidden plain checkbox too, not just Turnstile — and waits until *every* widget has a token before submitting
- **Hardening:** ad-overlay removal, network ad-blocking during solves, optional WebGL spoof, persistent browser profile for a warm `cf_clearance`
- **`solve_sto_modal`:** now clicks the provider's play button directly (`data-play-url`) instead of blindly navigating to the redirect URL; new `redirect_url` parameter
- All behavior toggles are controllable via `ANIWORLD_*` env vars (no UI change, solver logic only)

## New environment variables
All optional, all default to the behavior described (no `.env` changes required to keep current behavior):

| Variable | Default | Effect |
|---|---|---|
| `ANIWORLD_CAPTCHA_MANUAL` | off | Never auto-click a challenge widget — only the user's own click (CLI window / Web UI) counts |
| `ANIWORLD_CAPTCHA_VISIBLE` | off | Show the captcha browser window instead of pushing it off-screen |
| `ANIWORLD_CAPTCHA_TIMEOUT` | `300`/`90`s (code default) | Overrides the solve timeout in seconds |
| `ANIWORLD_NO_ADBLOCK` | adblock on | Disables the network ad-blocker during solves (try if a captcha won't load) |
| `ANIWORLD_CAPTCHA_NO_ADTAB_GUARD` | guard on | Disables auto-closing of pop-up ad tabs during `solve_sto_modal` |
| `ANIWORLD_CAPTCHA_NO_OVERLAY_REMOVAL` | removal on | Disables removal of invisible full-page ad-overlay links |
| `ANIWORLD_CAPTCHA_NO_UA_SYNC` | sync on | Disables syncing the session's User-Agent to the solving browser's real UA |
| `ANIWORLD_SPOOF_WEBGL` | off | Spoofs the WebGL renderer string (Intel/Mesa) — only useful on GPU-less servers/Docker |
| `ANIWORLD_PERSISTENT_PROFILE` | auto (on in Docker) | Forces a persistent Chromium profile on any platform |
| `ANIWORLD_NO_PERSISTENT_PROFILE` | — | Forces an ephemeral (non-persistent) profile even in Docker |
| `ANIWORLD_BROWSER_PROFILE` | `~/.aniworld/browser-profile` | Custom path for the persistent profile directory |
| `ANIWORLD_DOCKER` | auto-detected via `/.dockerenv` | Manually flags the process as running in Docker |

## Deliberately left out
- MediaForge's DNS routing (`chromium_dns_args`/`mirrors.py`) — a separate, project-wide DoH infrastructure that doesn't exist here

## Compatibility
- `playwright_get_iframe_url`, `playwright_get_hanime_stream_url`, `playwright_get_cineby_stream_url` kept unchanged
- `get_captcha_status()` / `_captcha_state` polling preserved
- Only external call-site change: `models/s_to/episode.py` now passes `redirect_url` to `solve_sto_modal`

## Testing
- `py_compile` on all changed files
- Module import verified in isolation (`aniworld.playwright.captcha`, `aniworld.web.captcha`), `solve_sto_modal` signature checked
- No leftover `MEDIAFORGE_` references in the code