### PR TITLE
Fix 'weiter' button not clicked after solving both captchas on s.to issue

### DIFF
--- a/src/aniworld/playwright/captcha.py
+++ b/src/aniworld/playwright/captcha.py
@@ -991,10 +991,28 @@ _ALTCHA_STATE_JS = """
 () => {
   const el = document.querySelector('altcha-widget');
   if (!el) return null;
+  // Preferred: the widget's JS API (works in normal browser contexts).
   try {
     if (typeof el.getState === 'function') return el.getState();
   } catch (e) {}
-  return el.getAttribute('state') || 'unverified';
+  // Fallback for automation contexts where the custom element's methods are
+  // not visible to page.evaluate (seen with patchright: window.customElements
+  // is null in the evaluate context even though the widget works fine in the
+  // page's main world). The widget mirrors its state onto the inner .altcha
+  // container's data-state attribute and, once solved, fills a hidden
+  // <input name="altcha"> with the signed payload — plain DOM, always readable.
+  try {
+    const box = el.querySelector('.altcha');
+    if (box) {
+      const ds = box.getAttribute('data-state');
+      if (ds) return ds;
+    }
+  } catch (e) {}
+  try {
+    const payload = document.querySelector('input[name="altcha"]');
+    if (payload && payload.value && payload.value.length > 20) return 'verified';
+  } catch (e) {}
+  return 'unverified';
 }
 """
 
@@ -1002,12 +1020,32 @@ _ALTCHA_VERIFY_JS = """
 () => {
   const el = document.querySelector('altcha-widget');
   if (!el) return false;
+  // Read current state via the JS API, falling back to the data-state
+  // attribute (see _ALTCHA_STATE_JS for why the API can be unreachable).
+  let state = null;
+  try { if (typeof el.getState === 'function') state = el.getState(); } catch (e) {}
+  if (!state) {
+    try {
+      const box = el.querySelector('.altcha');
+      state = box ? box.getAttribute('data-state') : null;
+    } catch (e) {}
+  }
+  // Already done or already computing — don't restart a running PoW.
+  if (state === 'verified' || state === 'verifying') return true;
+  // Preferred: the widget's own verify() method (normal browser contexts).
   try {
-    const state = (typeof el.getState === 'function') ? el.getState() : null;
-    // Already done or already computing — don't restart a running PoW.
-    if (state === 'verified' || state === 'verifying') return true;
     if (typeof el.verify === 'function') {
       el.verify();
+      return true;
+    }
+  } catch (e) {}
+  // Fallback: click the widget's light-DOM checkbox. The click event reaches
+  // the widget's change listener in the page's main world and starts the
+  // proof-of-work exactly like a real user click.
+  try {
+    const cb = el.querySelector('input[type="checkbox"]');
+    if (cb && !cb.checked && !cb.disabled) {
+      cb.click();
       return true;
     }
   } catch (e) {}


### PR DESCRIPTION
# Fix: "Weiter" button never clicked after ALTCHA + Turnstile are solved

## Issue

`solve_sto_modal()` opens episode page, clicks VOE play button, and the
"Video wird vorbereitet…" modal appears. Both widgets visibly solve, but **Weiter** is never clicked.
After the 90 s timeout the function returns `None`, which prints as the following in the TUI:

```
ValueError: Failed to resolve provider URL for VOE from redirect https://serienstream.to/r?t=…
RuntimeError: Download failed for all providers. VOE: …
```

Pressing **Weiter** by hand works, because the widgets really are solved in the
browser - the script just can't *see* one of them as solved.

## Root cause

`_ChallengeSolver.ready_to_submit()` only clicks Weiter once every detected
challenge kind reports ready. The `altcha` kind is considered ready when
`_altcha_widget_state()` returns `'verified'`, which relied exclusively on the
widget's JS api:

```js
const el = document.querySelector('altcha-widget');
if (typeof el.getState === 'function') return el.getState();
return el.getAttribute('state') || 'unverified';
```

Under **patchright**, `page.evaluate()` runs in a context where
`window.customElements === null` and custom elements appear unupgraded -
`el.getState` / `el.verify` are `undefined` there, even though the
`<altcha-widget>` works perfectly in the page itself...
 So:

- `_altcha_widget_state()` fell back to `'unverified'` forever,
- `_trigger_altcha_widget()` couldn't call `el.verify()` and returned `False`,
- `ready_to_submit()` therefore never returned `True` → Weiter never clicked → timeout.

(The "I'm not a robot" checkbox click *did* start ALTCHA's proof-of-work —
that's why the widget showed "Verified". Only the state detection was blind.)

## Fix

Read/trigger ALTCHA through plain-DOM signals that are visible in any JS
context. The widget mirrors its state onto the inner container's
`data-state` attribute (`<div class="altcha" data-state="verified">`), once
solved, fills a hidden `<input name="altcha">` with the signed payload - both
are plain DOM and always readable by `page.evaluate()`. Triggering falls back
to clicking widget's light-DOM checkbox (its change listener lives in the
page's main world and starts the PoW like a real click).

Only two JS snippets in `src/aniworld/playwright/captcha.py` change
(`_ALTCHA_STATE_JS`, `_ALTCHA_VERIFY_JS`). 


## Testing Environment
**OS:** Garuda Linux, KDE, CachyOS Kernel
**Kernel Version:** 7.1.3
**Python Version:** 3.14.6