### PR TITLE
Fix mpv watch playback failing with "[ffmpeg] https: HTTP error 400 Bad Request"

### DIFF
--- a/src/aniworld/extractors/provider/filemoon.py
+++ b/src/aniworld/extractors/provider/filemoon.py
@@ -302,7 +302,7 @@ if __name__ == "__main__":
         print("=" * 25)
 
         print(
-            f'mpv "{direct_link}" --http-header-fields=User-Agent: "{DEFAULT_USER_AGENT}"'
+            f'mpv "{direct_link}" --user-agent="{DEFAULT_USER_AGENT}"'
         )
 
         print("=" * 25)

--- a/src/aniworld/extractors/provider/loadx.py
+++ b/src/aniworld/extractors/provider/loadx.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         print("=" * 25)
 
         print(
-            f'mpv "{direct_link}" --http-header-fields=User-Agent: "{DEFAULT_USER_AGENT}"'
+            f'mpv "{direct_link}" --user-agent="{DEFAULT_USER_AGENT}"'
         )
 
         print("=" * 25)

--- a/src/aniworld/extractors/provider/luluvdo.py
+++ b/src/aniworld/extractors/provider/luluvdo.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         print("=" * 25)
 
         print(
-            f'mpv "{direct_link}" --http-header-fields=User-Agent: "{DEFAULT_USER_AGENT}"'
+            f'mpv "{direct_link}" --user-agent="{DEFAULT_USER_AGENT}"'
         )
 
         print("=" * 25)

--- a/src/aniworld/extractors/provider/megakino.py
+++ b/src/aniworld/extractors/provider/megakino.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         print("=" * 25)
 
         print(
-            f'mpv "{direct_link}" --http-header-fields=User-Agent: "{DEFAULT_USER_AGENT}"'
+            f'mpv "{direct_link}" --user-agent="{DEFAULT_USER_AGENT}"'
         )
 
         print("=" * 25)

--- a/src/aniworld/extractors/provider/streamtape.py
+++ b/src/aniworld/extractors/provider/streamtape.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         print("=" * 25)
 
         print(
-            f'mpv "{direct_link}" --http-header-fields=User-Agent: "{DEFAULT_USER_AGENT}"'
+            f'mpv "{direct_link}" --user-agent="{DEFAULT_USER_AGENT}"'
         )
 
         print("=" * 25)

--- a/src/aniworld/extractors/provider/vidoza.py
+++ b/src/aniworld/extractors/provider/vidoza.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
         print("=" * 25)
 
         print(
-            f'mpv "{direct_link}" --http-header-fields=User-Agent: "{DEFAULT_USER_AGENT}"'
+            f'mpv "{direct_link}" --user-agent="{DEFAULT_USER_AGENT}"'
         )
 
         print("=" * 25)

--- a/src/aniworld/extractors/provider/voe.py
+++ b/src/aniworld/extractors/provider/voe.py
@@ -296,7 +296,7 @@ if __name__ == "__main__":
         print("=" * 25)
 
         print(
-            f'mpv "{direct_link}" --http-header-fields=User-Agent: "{DEFAULT_USER_AGENT}"'
+            f'mpv "{direct_link}" --user-agent="{DEFAULT_USER_AGENT}"'
         )
 
         print("=" * 25)

--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -241,6 +241,25 @@ def _build_provider_failure_message(action_name, provider_errors):
     return f"{action_name} failed for all providers. {details}"
 
 
+def _build_player_header_args(headers):
+    # mpv parses --http-header-fields as a comma-separated list, so values
+    # containing commas (User-Agent's "(KHTML, like Gecko)", Accept-Language's
+    # "en-US,en;q=0.5") get split into malformed header lines and CDNs reply
+    # with "400 Bad Request" (issue #200). Use the dedicated single-value
+    # options where they exist and append the rest one at a time, which
+    # bypasses list splitting entirely.
+    args = []
+    for key, value in headers.items():
+        key_lower = key.lower()
+        if key_lower == "user-agent":
+            args.append(f"--user-agent={value}")
+        elif key_lower == "referer":
+            args.append(f"--referrer={value}")
+        else:
+            args.append(f"--http-header-fields-append={key}: {value}")
+    return args
+
+
 def _build_blocking_player_command(player_path, stream_url):
     player_name = os.path.basename(str(player_path)).lower()
     if player_name.startswith("iina"):
@@ -1301,8 +1320,7 @@ def watch(self):
                 cmd.extend(base_args)
 
                 if headers:
-                    header_args = [f"{k}: {v}" for k, v in headers.items()]
-                    cmd.append("--http-header-fields=" + ",".join(header_args))
+                    cmd.extend(_build_player_header_args(headers))
 
                 print(format_command_for_shell(cmd))
                 process = subprocess.run(cmd)
@@ -1417,8 +1435,7 @@ def syncplay(self):
     headers = PROVIDER_HEADERS_W.get(provider_name, {})
 
     if headers:
-        header_args = [f"{k}: {v}" for k, v in headers.items()]
-        cmd.append("--http-header-fields=" + ",".join(header_args))
+        cmd.extend(_build_player_header_args(headers))
 
     print(format_command_for_shell(cmd))
     logger.debug("\n" + format_command_for_shell(cmd))


### PR DESCRIPTION
# Fix mpv watch playback failing with "HTTP error 400 Bad Request"

Fixes Issue#200

## Root cause

mpv parses `--http-header-fields` as a comma-separated list, but some header values contain commas themselves (User-Agent `(KHTML, like Gecko)`, `Accept-Language: en-US,en;q=0.5`, `Accept-Encoding: gzip, deflate`). mpv splits them apart, ffmpeg sends the resulting malformed headers, and the CDN rejects the request with 400. Downloads worked because they don't go through mpv — it was never provider fingerprinting.

## Fix

New helper `_build_player_header_args()` (used by `watch()` and `syncplay()`) that passes headers safely:

- `User-Agent` → `--user-agent=...`
- `Referer` → `--referrer=...`
- everything else → one `--http-header-fields-append=Field: value` per header (appends a single item, no comma splitting)

Also updated the copy-paste mpv hints in the extractors' `__main__` blocks to use `--user-agent=` instead of the broken pattern.

## Testing

Verified the generated argument list for the VOE header set — all headers now arrive intact. Watch on Windows with mpv previously failed with 400 on VOE, now plays.