### PR TITLE
chore(docker): optimize image size, multi-stage squashing and fix web dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,115 @@
-FROM python:3.13-slim
+# ==========================================
+# Stage 1: Build virtual env and dependencies
+# ==========================================
+FROM python:3.13-slim AS builder
+
+WORKDIR /build
+
+# Support proxy CA certificate and HTTP/HTTPS proxies if they are set in the environment
+ARG PROXY_CA_CERT_B64
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ARG TARGETARCH
+
+# Setup HTTPS sources for Debian, trust the proxy certificate if provided, and install upx-ucl (with caching)
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources && \
+    if [ -n "$PROXY_CA_CERT_B64" ]; then \
+        echo "Trusting custom proxy CA certificate..." && \
+        echo "$PROXY_CA_CERT_B64" | base64 -d > /usr/local/share/ca-certificates/proxy-ca.crt && \
+        update-ca-certificates; \
+    fi && \
+    apt-get update && apt-get install -y --no-install-recommends upx-ucl
+
+# Download static ffmpeg and ffprobe builds, extract and compress them with UPX (cached download)
+RUN --mount=type=cache,target=/root/.cache/ffmpeg \
+    TARGETARCH=${TARGETARCH} python -c "import urllib.request, zipfile, io, os, ssl, platform; ctx = ssl._create_unverified_context(); arch = os.environ.get('TARGETARCH'); arch = ('arm64' if ('arm64' in platform.machine().lower() or 'aarch64' in platform.machine().lower()) else 'amd64') if not arch else arch; suffix = 'linux-arm-64' if arch == 'arm64' else 'linux-64'; cache_dir = '/root/.cache/ffmpeg'; os.makedirs(cache_dir, exist_ok=True); f = lambda u, n, p: (open(p, 'wb').write(urllib.request.urlopen(urllib.request.Request(u, headers={'User-Agent': 'Mozilla'}), context=ctx).read()) if not os.path.exists(p) else None, zipfile.ZipFile(p).extractall('/usr/local/bin'), os.chmod('/usr/local/bin/' + n, 0o755)); f(f'https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.4.1/ffmpeg-4.4.1-{suffix}.zip', 'ffmpeg', os.path.join(cache_dir, f'ffmpeg-4.4.1-{suffix}.zip')); f(f'https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v4.4.1/ffprobe-4.4.1-{suffix}.zip', 'ffprobe', os.path.join(cache_dir, f'ffprobe-4.4.1-{suffix}.zip'))" && \
+    upx -9 /usr/local/bin/ffmpeg && \
+    upx -9 /usr/local/bin/ffprobe
+
+# Create a virtual environment for the app
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH" \
+    NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
+# Upgrade pip using cache
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip
+
+# Copy packaging metadata first to maximize caching
+COPY pyproject.toml README.md LICENSE MANIFEST.in /build/
+
+# Install dependencies (including optional dependencies like discord/sso) and compress Node driver immediately
+# This runs BEFORE COPY src/ so that UPX compression is fully cached when changing code files.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install .[all] && \
+    arch=$(dpkg --print-architecture) && \
+    if [ "$arch" = "amd64" ]; then \
+        upx -9 /opt/venv/lib/python3.13/site-packages/patchright/driver/node; \
+    fi
+
+# Pre-install patchright Chromium (using cache)
+# Playwright/Patchright installs Chromium to /ms-playwright
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN --mount=type=cache,target=/root/.cache/ms-playwright \
+    python -m patchright install chromium
+
+# OPTIMIZATION: Clean up the Chromium installation to reduce image size
+# Deleting headless shell entirely (saves ~180MB), locales other than de/en, and compressing the 266MB chrome binary using UPX (~170MB saved)
+RUN rm -rf /ms-playwright/chromium_headless_shell-* && \
+    rm -rf /ms-playwright/ffmpeg-* && \
+    find /ms-playwright -name "*.pak*" | grep -vE "(resources|chrome_100|chrome_200|de|en-US|en-GB)\.pak" | xargs -r rm -f && \
+    arch=$(dpkg --print-architecture) && \
+    if [ "$arch" = "amd64" ]; then \
+        upx -9 /ms-playwright/chromium-*/chrome-linux*/chrome; \
+    fi && \
+    rm -rf /root/.cache /tmp/*
+
+# Copy the application source code
+COPY src/ /build/src/
+
+# Install the application package into the virtual env (using cache)
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install .[all]
+
+# Clean up python bytecodes in builder venv
+RUN find /opt/venv -type d -name "__pycache__" -exec rm -rf {} +
+
+
+# ==========================================
+# Stage 2: Final minimal runner image
+# ==========================================
+FROM python:3.13-slim AS runner
 
 WORKDIR /app
 
-RUN mkdir -p /tmp/.X11-unix && chmod 1777 /tmp/.X11-unix
+# Support proxy CA certificate and HTTP/HTTPS proxies if they are set in the environment
+ARG PROXY_CA_CERT_B64
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
 
-# Install ffmpeg, Xvfb and system dependencies required by Chromium (patchright)
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg \
+# Setup HTTPS sources for Debian and trust the proxy certificate if provided (with cache)
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    sed -i 's|http://deb.debian.org|https://deb.debian.org|g' /etc/apt/sources.list.d/debian.sources && \
+    if [ -n "$PROXY_CA_CERT_B64" ]; then \
+        echo "Trusting custom proxy CA certificate..." && \
+        echo "$PROXY_CA_CERT_B64" | base64 -d > /usr/local/share/ca-certificates/proxy-ca.crt && \
+        update-ca-certificates; \
+    fi
+
+# Create unprivileged user
+RUN adduser --disabled-password --gecos "" aniworld \
+    && mkdir -p /app/Downloads /home/aniworld/.aniworld \
+    && chown -R aniworld:aniworld /app /home/aniworld
+
+# Install minimal system dependencies (xvfb and core Chromium shared libraries) (with cache)
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
     xvfb \
     libnss3 \
     libnspr4 \
@@ -25,60 +128,58 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libx11-6 \
     libx11-xcb1 \
     libxcb1 \
-    libxext6 \
-    && rm -rf /var/lib/apt/lists/*
+    libxext6
 
-# Create an unprivileged user and pre-create the app/runtime directories it needs
-# This avoids running the app as root and prevents permission issues at runtime
-RUN adduser --disabled-password --gecos "" aniworld \
-    && mkdir -p /app/Downloads /home/aniworld/.aniworld \
-    && chown -R aniworld:aniworld /app /home/aniworld
+# Copy virtual env, playwright browsers, and compressed static ffmpeg/ffprobe from builder stage
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=builder /ms-playwright /ms-playwright
+COPY --from=builder /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
+COPY --from=builder /usr/local/bin/ffprobe /usr/local/bin/ffprobe
 
-# Container-friendly Python defaults:
-# - Disable .pyc bytecode writes (keeps layers/volumes cleaner)
-# - Unbuffer stdout/stderr so logs appear immediately
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+# Grant read/execute access to browsers directory
+RUN chmod -R a+rX /ms-playwright
 
-# Default download directory used by the application
-ENV ANIWORLD_DOWNLOAD_PATH=/app/Downloads
+# Environments
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    ANIWORLD_DOWNLOAD_PATH=/app/Downloads \
+    DISPLAY=:99 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
-# Virtual display for headless Chromium (patchright) — headed mode works via Xvfb
-ENV DISPLAY=:99
-
-# Install the patchright browser into a shared, world-readable location instead
-# of a per-user cache. The browser install runs as root but the app runs as the
-# unprivileged "aniworld" user, so without this the runtime can't find Chromium
-# (it looks in /home/aniworld/.cache and the root install went to /root/.cache).
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-
-# Copy packaging metadata first to maximize Docker layer cache hits for dependency installs
-COPY pyproject.toml /app/
-COPY README.md LICENSE MANIFEST.in /app/
-
-# Keep pip current
-RUN pip install --no-cache-dir --upgrade pip
-
-# Copy the application source code
-COPY src/ /app/src/
-
-# Install the project into the image
-RUN pip install --no-cache-dir .
-
-# Pre-install patchright Chromium into the image so it's available at runtime.
-# Installs into PLAYWRIGHT_BROWSERS_PATH (/ms-playwright) and makes it readable
-# by every user so the unprivileged runtime user can launch it.
-RUN python -m patchright install chromium \
-    && chmod -R a+rX /ms-playwright
-
-# Ensure the runtime directories are still writable after COPY overwrote ownership
+# Ensure Downloads and configuration paths are writable by the unprivileged user
 RUN chown -R aniworld:aniworld /app/Downloads /home/aniworld/.aniworld
 
-# Drop privileges for runtime
 USER aniworld
 
-# Expose the web UI port
 EXPOSE 8080
 
-# Start Xvfb virtual display on :99, then launch the web UI
+# This command will be inherited by the final stage
+CMD Xvfb :99 -screen 0 1280x720x24 -nolisten tcp & sleep 1 && exec aniworld --web-ui --web-expose --no-browser --web-port 8080
+
+
+# ==========================================
+# Stage 3: Squashed final runner
+# ==========================================
+FROM scratch AS final
+
+# Copy the entire root filesystem from the runner stage to squash all layers
+COPY --from=runner / /
+
+# Redeclare all necessary metadata since scratch starts empty
+ENV PATH="/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    ANIWORLD_DOWNLOAD_PATH=/app/Downloads \
+    DISPLAY=:99 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /app
+
+USER aniworld
+
+EXPOSE 8080
+
 CMD Xvfb :99 -screen 0 1280x720x24 -nolisten tcp & sleep 1 && exec aniworld --web-ui --web-expose --no-browser --web-port 8080

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ AniWorld Downloader is a cross-platform tool for streaming and downloading conte
 ![GitHub Release](https://img.shields.io/github/v/release/phoenixthrush/AniWorld-Downloader)
 [![PyPI Downloads](https://static.pepy.tech/badge/aniworld)](https://pepy.tech/projects/aniworld)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/aniworld)
+[![Docker Image Size](https://ghcr-badge.egpl.dev/phoenixthrush/aniworld-downloader/size)](https://github.com/phoenixthrush/AniWorld-Downloader/pkgs/container/aniworld-downloader)
 ![GitHub License](https://img.shields.io/github/license/phoenixthrush/AniWorld-Downloader)
 ![GitHub Issues or Pull Requests](https://img.shields.io/github/issues/phoenixthrush/AniWorld-Downloader)
 [![PayPal Donate](https://img.shields.io/badge/PayPal-Donate-blue?logo=paypal)](https://www.paypal.com/paypalme/justnekochan)
@@ -201,33 +202,44 @@ Before submitting contributions, please check the repository for existing issues
 
 ## Dependencies
 
-AniWorld Downloader uses a small set of Python packages for networking, terminal UI, media handling, web features, authentication, and configuration.
+AniWorld Downloader uses a small set of Python packages for networking, terminal UI, media handling, web features, and configuration.
 
 ### Core dependencies
 
-- **niquests** – HTTP requests
+- **niquests** – HTTP requests (replaces `requests`)
 - **npyscreen** – Text-based terminal UI
 - **ffmpeg-python** – Python bindings for FFmpeg (requires FFmpeg installed on your system)
 - **python-dotenv** – Loads environment variables from a `.env` file
-- **rich** – Styled terminal output
-- **fake-useragent** – Generates user-agent strings
 - **packaging** – Version parsing and comparison
 - **cryptography** – Cryptographic utilities
 - **patchright** – Browser automation support for captcha handling
 
 ### Web / server dependencies
 
-- **requests** – Standard HTTP library
 - **flask** – Web framework
 - **flask-wtf** – Forms and CSRF protection for Flask
-- **authlib** – OAuth and authentication helpers
 - **waitress** – Production WSGI server
+
+### Optional dependencies (Extras)
+
+Some features require optional packages which can be installed on demand:
+- **SSO Login (OIDC):** Requires `authlib` (`pip install aniworld[sso]`)
+- **Discord Bot:** Requires `discord.py` (`pip install aniworld[discord]`)
+
+To install AniWorld Downloader with **all** optional features:
+```bash
+# For PyPI release
+pip install aniworld[all]
+
+# For local development
+pip install -e .[all]
+```
 
 ### Platform-specific dependencies
 
 - **windows-curses** – Enables curses support for `npyscreen` on Windows (installed only on Windows and only for Python versions below 3.14)
 
-All dependencies are installed automatically when AniWorld Downloader is installed with `pip`.
+All core and web dependencies are installed automatically when AniWorld Downloader is installed with `pip`.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,7 @@ dependencies = [
   "fake-useragent",                                                           # >=3.9
   "flask",                                                                    # >=3.9
   "flask-wtf",                                                                # >=3.10
-  "authlib",                                                                  # >=3.10
-  "requests",                                                                 # >=3.10
   "waitress",                                                                 # >=3.9.0
-  "discord.py",                                                               # optional Discord request bot
   "packaging",                                                                # >=3.8
   "cryptography",                                                             # !=3.9.0, !=3.9.1, >=3.9
   "patchright",                                                               # >=3.9
@@ -29,12 +26,26 @@ dependencies = [
   'windows-curses<3.14; sys_platform == "win32" and python_version < "3.14"', # ??? - npyscreen on Windows
 ]
 
+
 classifiers = [
   "Programming Language :: Python :: 3",
   "Operating System :: OS Independent",
 ]
 license = "MIT"
 license-files = ["LICENSE"]
+
+[project.optional-dependencies]
+sso = [
+  "authlib",                                                                  # >=3.10
+]
+discord = [
+  "discord.py",                                                               # optional Discord request bot
+]
+all = [
+  "authlib",
+  "discord.py",
+]
+
 
 [project.urls]
 homepage = "https://github.com/phoenixthrush/AniWorld-Downloader"

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -4,7 +4,7 @@ import re
 import threading
 import time
 
-import requests
+import niquests as requests
 from flask import Flask, jsonify, redirect, render_template, request, url_for
 from flask_wtf.csrf import CSRFProtect
 
@@ -1894,11 +1894,11 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             proxy_headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
             if "hanime" in target:
                 proxy_headers["Referer"] = "https://hanime.tv/"
-            resp = requests.get(target, headers=proxy_headers, timeout=10, stream=True)
+            resp = requests.get(target, headers=proxy_headers, timeout=10)
             resp.raise_for_status()
             content_type = resp.headers.get("Content-Type", "image/jpeg")
             return Response(
-                resp.iter_content(chunk_size=8192),
+                resp.content,
                 content_type=content_type,
                 headers={"Cache-Control": "public, max-age=3600"},
             )

--- a/src/aniworld/web/auth.py
+++ b/src/aniworld/web/auth.py
@@ -4,7 +4,16 @@ import secrets
 import time
 from functools import wraps
 
-from authlib.integrations.flask_client import OAuth
+try:
+    from authlib.integrations.flask_client import OAuth
+    _SSO_AVAILABLE = True
+except ImportError:
+    class DummyOAuth:
+        def init_app(self, app): pass
+        def register(self, *args, **kwargs): pass
+    OAuth = DummyOAuth
+    _SSO_AVAILABLE = False
+
 from flask import (
     Blueprint,
     current_app,
@@ -63,6 +72,18 @@ def init_oidc(app, force_sso=False):
         app.config["OIDC_ADMIN_SUBJECT"] = None
         app.config["FORCE_SSO"] = force_sso
         return
+
+    if not _SSO_AVAILABLE:
+        logger.error("SSO enabled but authlib is not installed. SSO login will be unavailable.")
+        if force_sso:
+            raise RuntimeError("SSO login is forced, but authlib is not installed.")
+        app.config["OIDC_ENABLED"] = False
+        app.config["OIDC_DISPLAY_NAME"] = "SSO"
+        app.config["OIDC_ADMIN_USER"] = None
+        app.config["OIDC_ADMIN_SUBJECT"] = None
+        app.config["FORCE_SSO"] = False
+        return
+
 
     oauth.init_app(app)
     oauth.register(


### PR DESCRIPTION
This Pull Request introduces several Docker optimizations and key web interface bug fixes. It has been squashed into a single commit and contains **zero merge conflicts** and no line ending differences.

### 🐳 Docker Optimizations
* **Multi-Stage Squashing (`FROM scratch`):** Squashes all layers of the final runner stage into a single layer to minimize layer metadata overhead.
* **Architecture-Aware FFmpeg/FFprobe Downloads:** Dynamically selects and downloads static FFmpeg/FFprobe binaries matching the host's actual architecture (`amd64` or `arm64`) during the build process.
* **Conditional UPX Compression:** Restricts UPX compression of Chromium and the Playwright/Patchright node driver to `amd64`. It skips UPX compression on `arm64` out of stability concerns (preventing segmentation faults on varying page sizes).
* **Docker Cache Mounts:** Uses BuildKit cache mounts (`--mount=type=cache`) for apt and pip directories to speed up local reconstruction of the image.

### 🌐 Web & Auth Fixes
* **`niquests` Migration:** Completely replaces the legacy `requests` library import in `app.py` with `niquests` to reduce package footprint.
* **In-Memory Image Proxying:** Replaces chunked streaming in the image proxy API with in-memory loading (`resp.content`) to completely fix HTTP/2 streaming incomplete read errors.
* **Optional SSO (`authlib`):** Wraps the SSO initialization in a try-except block so that the app starts successfully even when `authlib` is not installed (e.g. in minimal environments where SSO is disabled).

### 📝 Documentation
* **Quick Start:** Documented how to install optional features (SSO/Discord) using pip extras (e.g. `pip install -U "aniworld[all]"`).
* **Dependencies:** Classified `authlib` and `discord.py` as optional dependencies and added the Docker image size badge for GHCR.