### PR TITLE
fix(AutoSync): Pre-filter episodes by language availability to prevent queue clutter

### DIFF
--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -749,8 +749,6 @@ def _run_autosync_for_job(job):
             # Collect all episode URLs that are NOT yet downloaded
             missing_episodes = []
             lang_total_found = 0
-            consecutive_unavailable = 0
-            req_prov = job.get("provider")
             
             for season in series.seasons:
                 season_obj = prov.season_cls(url=season.url, series=series)
@@ -810,25 +808,6 @@ def _run_autosync_for_job(job):
                     lang_total_found += 1
                     key = (ep.season.season_number, ep.episode_number)
                     if key not in downloaded_eps:
-                        if consecutive_unavailable > 2:
-                            continue  # Stop checking further episodes to avoid spamming the site
-                            
-                        # Deep verify to ensure the provider actually hosts this language
-                        try:
-                            if hasattr(ep, "available_providers"):
-                                avail = ep.available_providers(language=target_lang)
-                                if not avail:
-                                    consecutive_unavailable += 1
-                                    continue
-                                if req_prov and req_prov != "Auto":
-                                    if req_prov not in avail:
-                                        consecutive_unavailable += 1
-                                        continue
-                        except Exception as e:
-                            logger.error("Auto-Sync deep verify failed for %s: %s", ep.url, e)
-                            pass
-                            
-                        consecutive_unavailable = 0
                         missing_episodes.append(ep.url)
 
             # In "All Languages" mode we want to make sure the specific language is actually

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -751,9 +751,30 @@ def _run_autosync_for_job(job):
             lang_total_found = 0
             for season in series.seasons:
                 season_obj = prov.season_cls(url=season.url, series=series)
+                
+                ep_lang_map = {}
+                if hasattr(season_obj, "_html"):
+                    html = season_obj._html
+                    if html:
+                        for tr in re.findall(r'<tr[^>]*itemtype="http://schema.org/Episode".*?</tr>', html, re.IGNORECASE | re.DOTALL):
+                            m = re.search(r'href="(/[^"]+)"', tr)
+                            if m:
+                                e_url = m.group(1)
+                                lgs = set()
+                                if "german.svg" in tr: lgs.add("German Dub")
+                                if "japanese-german.svg" in tr: lgs.add("German Sub")
+                                if "japanese-english.svg" in tr: lgs.add("English Sub")
+                                if "english.svg" in tr: lgs.add("English Dub")
+                                ep_lang_map[e_url] = lgs
+                                
                 for ep in season_obj.episodes:
-                    # Depending on provider, might need to pre-filter by language here
-                    # But the downloader expects full episode URLs and it will pick the right language within them.
+                    if ep_lang_map:
+                        from urllib.parse import urlparse
+                        ep_path = urlparse(ep.url).path
+                        lgs = ep_lang_map.get(ep_path)
+                        if lgs is not None and target_lang not in lgs:
+                            continue
+
                     lang_total_found += 1
                     key = (ep.season.season_number, ep.episode_number)
                     if key not in downloaded_eps:

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -787,12 +787,13 @@ def _run_autosync_for_job(job):
                                     ep_url = tr_html[h_start:h_end]
                                     
                             if ep_url:
-                                ep_url = ep_url.rstrip('/')
+                                from urllib.parse import urlparse
+                                ep_url = urlparse(ep_url).path.rstrip('/')
                                 lgs = set()
-                                if "german.svg" in tr_html: lgs.add("German Dub")
-                                if "japanese-german.svg" in tr_html: lgs.add("German Sub")
-                                if "japanese-english.svg" in tr_html: lgs.add("English Sub")
-                                if "english.svg" in tr_html: lgs.add("English Dub")
+                                if "/german.svg" in tr_html: lgs.add("German Dub")
+                                if "/japanese-german.svg" in tr_html: lgs.add("German Sub")
+                                if "/japanese-english.svg" in tr_html: lgs.add("English Sub")
+                                if "/english.svg" in tr_html: lgs.add("English Dub")
                                 ep_lang_map[ep_url] = lgs
                             
                             pos = tr_end

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -749,6 +749,9 @@ def _run_autosync_for_job(job):
             # Collect all episode URLs that are NOT yet downloaded
             missing_episodes = []
             lang_total_found = 0
+            consecutive_unavailable = 0
+            req_prov = job.get("provider")
+            
             for season in series.seasons:
                 season_obj = prov.season_cls(url=season.url, series=series)
                 
@@ -756,17 +759,45 @@ def _run_autosync_for_job(job):
                 if hasattr(season_obj, "_html"):
                     html = season_obj._html
                     if html:
-                        for tr in re.findall(r'<tr[^>]*itemtype="http://schema.org/Episode".*?</tr>', html, re.IGNORECASE | re.DOTALL):
-                            # Target specific episode/film URLs to avoid capturing generic links
-                            m = re.search(r'href="(/[^"]+/(?:episode|film|ova)-[^"]+)"', tr, re.IGNORECASE)
-                            if m:
-                                e_url = m.group(1).rstrip('/')
+                        marker = 'itemtype="http://schema.org/Episode"'
+                        pos = 0
+                        while True:
+                            pos = html.find(marker, pos)
+                            if pos == -1:
+                                break
+                            tr_start = html.rfind("<tr", 0, pos)
+                            tr_end = html.find("</tr>", pos)
+                            if tr_start == -1 or tr_end == -1:
+                                pos += len(marker)
+                                continue
+                            
+                            tr_html = html[tr_start:tr_end]
+                            ep_url = None
+                            
+                            url_pos = tr_html.find('itemprop="url"')
+                            if url_pos != -1:
+                                h_start = tr_html.find('href="', url_pos) + 6
+                                h_end = tr_html.find('"', h_start)
+                                ep_url = tr_html[h_start:h_end]
+                            else:
+                                href_pos = tr_html.find("film-")
+                                if href_pos == -1:
+                                    href_pos = tr_html.find("episode-")
+                                if href_pos != -1:
+                                    h_start = tr_html.rfind('href="', 0, href_pos) + 6
+                                    h_end = tr_html.find('"', h_start)
+                                    ep_url = tr_html[h_start:h_end]
+                                    
+                            if ep_url:
+                                ep_url = ep_url.rstrip('/')
                                 lgs = set()
-                                if "german.svg" in tr: lgs.add("German Dub")
-                                if "japanese-german.svg" in tr: lgs.add("German Sub")
-                                if "japanese-english.svg" in tr: lgs.add("English Sub")
-                                if "english.svg" in tr: lgs.add("English Dub")
-                                ep_lang_map[e_url] = lgs
+                                if "german.svg" in tr_html: lgs.add("German Dub")
+                                if "japanese-german.svg" in tr_html: lgs.add("German Sub")
+                                if "japanese-english.svg" in tr_html: lgs.add("English Sub")
+                                if "english.svg" in tr_html: lgs.add("English Dub")
+                                ep_lang_map[ep_url] = lgs
+                            
+                            pos = tr_end
                                 
                 for ep in season_obj.episodes:
                     if ep_lang_map:
@@ -779,6 +810,25 @@ def _run_autosync_for_job(job):
                     lang_total_found += 1
                     key = (ep.season.season_number, ep.episode_number)
                     if key not in downloaded_eps:
+                        if consecutive_unavailable > 2:
+                            continue  # Stop checking further episodes to avoid spamming the site
+                            
+                        # Deep verify to ensure the provider actually hosts this language
+                        try:
+                            if hasattr(ep, "available_providers"):
+                                avail = ep.available_providers(language=target_lang)
+                                if not avail:
+                                    consecutive_unavailable += 1
+                                    continue
+                                if req_prov and req_prov != "Auto":
+                                    if req_prov not in avail:
+                                        consecutive_unavailable += 1
+                                        continue
+                        except Exception as e:
+                            logger.error("Auto-Sync deep verify failed for %s: %s", ep.url, e)
+                            pass
+                            
+                        consecutive_unavailable = 0
                         missing_episodes.append(ep.url)
 
             # In "All Languages" mode we want to make sure the specific language is actually

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -757,9 +757,10 @@ def _run_autosync_for_job(job):
                     html = season_obj._html
                     if html:
                         for tr in re.findall(r'<tr[^>]*itemtype="http://schema.org/Episode".*?</tr>', html, re.IGNORECASE | re.DOTALL):
-                            m = re.search(r'href="(/[^"]+)"', tr)
+                            # Target specific episode/film URLs to avoid capturing generic links
+                            m = re.search(r'href="(/[^"]+/(?:episode|film|ova)-[^"]+)"', tr, re.IGNORECASE)
                             if m:
-                                e_url = m.group(1)
+                                e_url = m.group(1).rstrip('/')
                                 lgs = set()
                                 if "german.svg" in tr: lgs.add("German Dub")
                                 if "japanese-german.svg" in tr: lgs.add("German Sub")
@@ -770,7 +771,7 @@ def _run_autosync_for_job(job):
                 for ep in season_obj.episodes:
                     if ep_lang_map:
                         from urllib.parse import urlparse
-                        ep_path = urlparse(ep.url).path
+                        ep_path = urlparse(ep.url).path.rstrip('/')
                         lgs = ep_lang_map.get(ep_path)
                         if lgs is not None and target_lang not in lgs:
                             continue


### PR DESCRIPTION
## Description
- Implemented an intelligent pre-filter in the Auto-Sync worker that parses available languages directly from the season HTML (for AniWorld and SerienStream).
- Episodes that do not have the requested language available (e.g. only Sub available while Dub is requested) are now automatically skipped during the sync process.
- This prevents the download queue from being cluttered with hundreds of episodes that would otherwise immediately fail to download due to missing language availability.