### PR TITLE
Fix FilmPalast search and Cloudflare connection issues

### DIFF
--- a/src/aniworld/config.py
+++ b/src/aniworld/config.py
@@ -121,6 +121,8 @@ LULUVDO_USER_AGENT = (
 # every run, even though the actual fetch only takes about a second
 GLOBAL_SESSION = Session(
     resolver=["doh+google://"],
+    disable_http3=True,
+    multiplexed=False,
     headers={
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         "Sec-Fetch-Site": "none",

--- a/src/aniworld/search.py
+++ b/src/aniworld/search.py
@@ -3,7 +3,7 @@ import os
 import random
 import re
 import niquests
-from urllib.parse import quote_plus, urljoin
+from urllib.parse import quote, quote_plus, urljoin
 
 try:
     from .ascii import display_ascii_art
@@ -746,7 +746,7 @@ def query_filmpalast(keyword):
     base = "https://filmpalast.to"
 
     def _run(term):
-        url = f"{base}/search/title/{quote_plus(term)}"
+        url = f"{base}/search/title/{quote(term)}"
         try:
             resp = GLOBAL_SESSION.get(
                 url,

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -1952,10 +1952,11 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
         if not target or not target.startswith(("http://", "https://")):
             return "", 400
         try:
+            from ..config import GLOBAL_SESSION
             proxy_headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"}
             if "hanime" in target:
                 proxy_headers["Referer"] = "https://hanime.tv/"
-            resp = requests.get(target, headers=proxy_headers, timeout=10)
+            resp = GLOBAL_SESSION.get(target, headers=proxy_headers, timeout=10)
             resp.raise_for_status()
             content_type = resp.headers.get("Content-Type", "image/jpeg")
             return Response(


### PR DESCRIPTION
1. Fixes FilmPalast search breaking with spaces by using `quote` instead of `quote_plus` (encoding as `%20` instead of `+`).\n2. Fixes FilmPalast and MangaFire connections failing with `ConnectionResetError` and `ConnectionRefusedError` by disabling HTTP/3 and multiplexing in Niquests, bypassing Cloudflare's strict TLS/QUIC blocking.\n3. Routes image proxy requests through `GLOBAL_SESSION` to benefit from the same Cloudflare-bypassing configuration.