### PR TITLE
fix: eliminate headless_shell requirement for Hanime/Cineby to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/ms-playwright \
     pip install patchright && \
     python -m patchright install chromium && \
-    rm -rf /ms-playwright/chromium_headless_shell-* && \
     rm -rf /ms-playwright/ffmpeg-* && \
     find /ms-playwright -name "*.pak*" | grep -vE "(resources|chrome_100|chrome_200|de|en-US|en-GB)\.pak" | xargs -r rm -f && \
     arch=$(dpkg --print-architecture) && \
     if [ "$arch" = "amd64" ]; then \
         upx -9 /opt/venv/lib/python3.13/site-packages/patchright/driver/node; \
         upx -9 /ms-playwright/chromium-*/chrome-linux*/chrome; \
+        upx -9 /ms-playwright/chromium_headless_shell-*/chrome-linux*/headless_shell; \
     fi && \
     chmod -R a+rX /ms-playwright && \
     rm -rf /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,17 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/ms-playwright \
     pip install patchright && \
     python -m patchright install chromium && \
-    rm -rf /ms-playwright/chromium_headless_shell-* && \
     rm -rf /ms-playwright/ffmpeg-* && \
     find /ms-playwright -name "*.pak*" | grep -vE "(resources|chrome_100|chrome_200|de|en-US|en-GB)\.pak" | xargs -r rm -f && \
+    headless_dir=$(ls -d /ms-playwright/chromium_headless_shell-* | head -n 1) && \
+    chrome_dir=$(ls -d /ms-playwright/chromium-* | grep -v headless_shell | head -n 1) && \
+    rm -rf "$headless_dir" && \
+    ln -s "$(basename "$chrome_dir")" "$headless_dir" && \
+    ln -s chrome "$chrome_dir/chrome-linux/headless_shell" && \
     arch=$(dpkg --print-architecture) && \
     if [ "$arch" = "amd64" ]; then \
         upx -9 /opt/venv/lib/python3.13/site-packages/patchright/driver/node; \
-        upx -9 /ms-playwright/chromium-*/chrome-linux*/chrome; \
+        upx -9 "$chrome_dir/chrome-linux/chrome"; \
     fi && \
     chmod -R a+rX /ms-playwright && \
     rm -rf /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,17 +41,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/ms-playwright \
     pip install patchright && \
     python -m patchright install chromium && \
+    rm -rf /ms-playwright/chromium_headless_shell-* && \
     rm -rf /ms-playwright/ffmpeg-* && \
     find /ms-playwright -name "*.pak*" | grep -vE "(resources|chrome_100|chrome_200|de|en-US|en-GB)\.pak" | xargs -r rm -f && \
-    headless_dir=$(ls -d /ms-playwright/chromium_headless_shell-* | head -n 1) && \
-    chrome_dir=$(ls -d /ms-playwright/chromium-* | grep -v headless_shell | head -n 1) && \
-    rm -rf "$headless_dir" && \
-    ln -s "$(basename "$chrome_dir")" "$headless_dir" && \
-    ln -s chrome "$chrome_dir/chrome-linux/headless_shell" && \
     arch=$(dpkg --print-architecture) && \
     if [ "$arch" = "amd64" ]; then \
         upx -9 /opt/venv/lib/python3.13/site-packages/patchright/driver/node; \
-        upx -9 "$chrome_dir/chrome-linux/chrome"; \
+        upx -9 /ms-playwright/chromium-*/chrome-linux*/chrome; \
     fi && \
     chmod -R a+rX /ms-playwright && \
     rm -rf /tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,11 +43,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     python -m patchright install chromium && \
     rm -rf /ms-playwright/ffmpeg-* && \
     find /ms-playwright -name "*.pak*" | grep -vE "(resources|chrome_100|chrome_200|de|en-US|en-GB)\.pak" | xargs -r rm -f && \
+    headless_dir=$(ls -d /ms-playwright/chromium_headless_shell-* | head -n 1) && \
+    chrome_dir=$(ls -d /ms-playwright/chromium-* | grep -v headless_shell | head -n 1) && \
+    rm -rf "$headless_dir" && \
+    ln -s "$(basename "$chrome_dir")" "$headless_dir" && \
+    ln -s chrome "$chrome_dir/chrome-linux/headless_shell" && \
     arch=$(dpkg --print-architecture) && \
     if [ "$arch" = "amd64" ]; then \
         upx -9 /opt/venv/lib/python3.13/site-packages/patchright/driver/node; \
-        upx -9 /ms-playwright/chromium-*/chrome-linux*/chrome; \
-        upx -9 /ms-playwright/chromium_headless_shell-*/chrome-linux*/headless_shell; \
+        upx -9 "$chrome_dir/chrome-linux/chrome"; \
     fi && \
     chmod -R a+rX /ms-playwright && \
     rm -rf /tmp/*

--- a/src/aniworld/playwright/captcha.py
+++ b/src/aniworld/playwright/captcha.py
@@ -1815,7 +1815,7 @@ def playwright_get_iframe_url(url: str, timeout: int = 20) -> str:
 
     try:
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=False, args=_stealth_launch_args(True))
+            browser = p.chromium.launch(headless=True, args=["--disable-gpu"])
             context = browser.new_context(viewport={"width": 1280, "height": 720})
             _inject_session_cookies(context, url)
             page = context.new_page()
@@ -1862,8 +1862,8 @@ def playwright_get_hanime_manifest_token(url: str, timeout: int = 15) -> str:
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch(
-                headless=False,
-                args=_stealth_launch_args(True),
+                headless=True,
+                args=["--disable-gpu"],
             )
             context = browser.new_context(
                 viewport={"width": 1280, "height": 720},
@@ -1976,7 +1976,7 @@ def playwright_get_cineby_stream_url(url: str, timeout: int = 40) -> str:
 
     try:
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=False, args=_stealth_launch_args(True))
+            browser = p.chromium.launch(headless=True, args=["--disable-gpu"])
             context = browser.new_context(
                 viewport={"width": 1280, "height": 720}, locale="en-US"
             )

--- a/src/aniworld/playwright/captcha.py
+++ b/src/aniworld/playwright/captcha.py
@@ -1815,7 +1815,7 @@ def playwright_get_iframe_url(url: str, timeout: int = 20) -> str:
 
     try:
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True, args=["--disable-gpu"])
+            browser = p.chromium.launch(headless=False, args=_stealth_launch_args(True))
             context = browser.new_context(viewport={"width": 1280, "height": 720})
             _inject_session_cookies(context, url)
             page = context.new_page()
@@ -1862,8 +1862,8 @@ def playwright_get_hanime_manifest_token(url: str, timeout: int = 15) -> str:
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch(
-                headless=True,
-                args=["--disable-gpu"],
+                headless=False,
+                args=_stealth_launch_args(True),
             )
             context = browser.new_context(
                 viewport={"width": 1280, "height": 720},
@@ -1976,7 +1976,7 @@ def playwright_get_cineby_stream_url(url: str, timeout: int = 40) -> str:
 
     try:
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True, args=["--disable-gpu"])
+            browser = p.chromium.launch(headless=False, args=_stealth_launch_args(True))
             context = browser.new_context(
                 viewport={"width": 1280, "height": 720}, locale="en-US"
             )


### PR DESCRIPTION
### Summary
Modified the internal Playwright `launch()` calls in `captcha.py` to use `headless=False` alongside offscreen stealth arguments, rather than explicitly requesting `headless=True`. 

### Why?
Previously, we aggressively deleted the `chromium_headless_shell` folder to save ~180MB in the Docker image. However, when the Hanime or Cineby extractors called `headless=True`, Playwright crashed because it expected that specific binary to exist.
By forcing Playwright to use the normal `chrome` binary (which we kept and compressed) and hiding the window offscreen, we completely eliminate the need for the `headless_shell` binary while keeping all headless/background functionality fully intact. 

This safely restores the 180MB space savings and fixes the Hanime extractor.