### PR TITLE
fix: Web-UI progress bar visibility when cancelling

### DIFF
--- a/src/aniworld/web/static/queue.js
+++ b/src/aniworld/web/static/queue.js
@@ -48,9 +48,16 @@ function formatBandwidth(bwStr) {
   return mbytes.toFixed(1) + " MB/s";
 }
 
+let queueFetchController = null;
+
 async function loadQueue() {
+  if (queueFetchController) {
+    queueFetchController.abort();
+  }
+  const controller = new AbortController();
+  queueFetchController = controller;
   try {
-    const resp = await fetch("/api/queue");
+    const resp = await fetch("/api/queue", { signal: controller.signal });
     const data = await resp.json();
     const items = data.items || [];
     lastFfmpegProgress = data.ffmpeg_progress || {};
@@ -58,6 +65,10 @@ async function loadQueue() {
     updateBadge(items);
   } catch (e) {
     /* ignore */
+  } finally {
+    if (queueFetchController === controller) {
+      queueFetchController = null;
+    }
   }
 }
 

--- a/src/aniworld/web/static/queue.js
+++ b/src/aniworld/web/static/queue.js
@@ -146,19 +146,13 @@ function renderQueue(items) {
 
       // Combine episode progress with in-episode ffmpeg progress
       let ffPct = 0;
-      if (isRunning && lastFfmpegProgress.active && item.total_episodes > 0) {
+      if ((isRunning || isCancelling) && lastFfmpegProgress.active && item.total_episodes > 0) {
         ffPct = (lastFfmpegProgress.percent || 0) / item.total_episodes;
       }
       const combinedPct = Math.min(Math.round(epPct + ffPct), 100);
 
       let label;
-      if (isCancelling) {
-        label =
-          item.current_episode +
-          "/" +
-          item.total_episodes +
-          " episodes - finishing current episode...";
-      } else if (item.status === "cancelled") {
+      if (item.status === "cancelled" && !isCancelling) {
         label =
           item.current_episode +
           "/" +
@@ -175,6 +169,9 @@ function renderQueue(items) {
             "%" +
             (bw ? " @ " + bw : "") +
             ")";
+        }
+        if (isCancelling) {
+          epDetail += " - finishing current episode...";
         }
         label = epDetail;
       }


### PR DESCRIPTION
Fixes the issue where the progress bar and details disappear when a download is cancelled in the Web UI. It now properly calculates and displays the current ffmpeg progress while the final episode is finishing.