### PR TITLE
feat: Add force cancel option and fix queue progress visibility

### DIFF
--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -486,7 +486,7 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
                 elif is_tty:
                     _print_cli_progress(percent, cur_time_str, cur_speed_str, label)
 
-                # --- stall detection ---
+                # --- stall and force cancel detection ---
                 if cur_frame != last_frame or cur_time != last_time:
                     last_frame = cur_frame
                     last_time = cur_time
@@ -498,6 +498,17 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
                     )
                     process.kill()
                     break
+
+                try:
+                    from ...web.db import is_queue_force_cancelled
+                    from ...playwright.captcha import _local
+                    qid = getattr(_local, "queue_id", None)
+                    if qid is not None and is_queue_force_cancelled(qid):
+                        logger.warning("[FFmpeg] Force cancel requested. Killing process.")
+                        process.kill()
+                        break
+                except Exception:
+                    pass
             elif line_str:
                 # Try to capture total duration from ffmpeg header
                 if total_duration == 0.0:
@@ -1242,6 +1253,23 @@ def download(self):
                     temp = self._episode_path.with_suffix(suffix)
                     if temp.exists():
                         temp.unlink()
+
+                try:
+                    from ...web.db import is_queue_force_cancelled
+                    from ...playwright.captcha import _local
+                    qid = getattr(_local, "queue_id", None)
+                    if qid is not None and is_queue_force_cancelled(qid):
+                        if self._episode_path.exists():
+                            self._episode_path.unlink()
+                        _remove_empty_dirs(
+                            self._folder_path,
+                            self._base_folder,
+                            protected=getattr(self, "selected_path", None),
+                        )
+                        raise e
+                except Exception as inner_e:
+                    if inner_e is e:
+                        raise
 
                 provider_errors[provider_name] = e
                 logger.warning(

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -45,6 +45,9 @@ from .db import (
     update_custom_path,
     add_to_queue,
     cancel_queue_item,
+    force_cancel_queue_item,
+    clear_force_cancelled,
+    is_queue_force_cancelled,
     clear_captcha_url,
     clear_completed,
     find_autosync_by_url,
@@ -604,7 +607,10 @@ def _queue_worker():
 
                 # Check for cancellation after each episode
                 if is_queue_cancelled(item["id"]):
-                    logger.info(f"Download cancelled for queue item {item['id']}")
+                    if is_queue_force_cancelled(item["id"]):
+                        logger.info(f"Download force cancelled for queue item {item['id']}")
+                    else:
+                        logger.info(f"Download cancelled for queue item {item['id']}")
                     update_queue_progress(item["id"], i + 1, "")
                     break
 
@@ -1894,6 +1900,13 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
     @app.route("/api/queue/<int:queue_id>/cancel", methods=["POST"])
     def api_queue_cancel(queue_id):
         ok, err = cancel_queue_item(queue_id)
+        if not ok:
+            return jsonify({"error": err}), 400
+        return jsonify({"ok": True})
+
+    @app.route("/api/queue/<int:queue_id>/force_cancel", methods=["POST"])
+    def api_queue_force_cancel(queue_id):
+        ok, err = force_cancel_queue_item(queue_id)
         if not ok:
             return jsonify({"error": err}), 400
         return jsonify({"ok": True})

--- a/src/aniworld/web/db.py
+++ b/src/aniworld/web/db.py
@@ -568,6 +568,25 @@ def clear_captcha_url(queue_id: int):
         conn.close()
 
 
+_force_cancelled_queue_ids = set()
+
+def force_cancel_queue_item(queue_id):
+    ok, err = cancel_queue_item(queue_id)
+    if not ok:
+        # If it's already cancelled, we can still force cancel it
+        if err == "Can only cancel running items":
+            conn = get_db()
+            try:
+                row = conn.execute("SELECT status FROM download_queue WHERE id = ?", (queue_id,)).fetchone()
+                if row and row["status"] == "cancelled":
+                    _force_cancelled_queue_ids.add(queue_id)
+                    return True, None
+            finally:
+                conn.close()
+        return False, err
+    _force_cancelled_queue_ids.add(queue_id)
+    return True, None
+
 def cancel_queue_item(queue_id):
     conn = get_db()
     try:
@@ -597,6 +616,12 @@ def is_queue_cancelled(queue_id):
         return row and row["status"] == "cancelled"
     finally:
         conn.close()
+
+def is_queue_force_cancelled(queue_id):
+    return queue_id in _force_cancelled_queue_ids
+
+def clear_force_cancelled(queue_id):
+    _force_cancelled_queue_ids.discard(queue_id)
 
 
 def remove_from_queue(queue_id):

--- a/src/aniworld/web/static/queue.js
+++ b/src/aniworld/web/static/queue.js
@@ -48,9 +48,16 @@ function formatBandwidth(bwStr) {
   return mbytes.toFixed(1) + " MB/s";
 }
 
+let queueFetchController = null;
+
 async function loadQueue() {
+  if (queueFetchController) {
+    queueFetchController.abort();
+  }
+  const controller = new AbortController();
+  queueFetchController = controller;
   try {
-    const resp = await fetch("/api/queue");
+    const resp = await fetch("/api/queue", { signal: controller.signal });
     const data = await resp.json();
     const items = data.items || [];
     lastFfmpegProgress = data.ffmpeg_progress || {};
@@ -58,6 +65,10 @@ async function loadQueue() {
     updateBadge(items);
   } catch (e) {
     /* ignore */
+  } finally {
+    if (queueFetchController === controller) {
+      queueFetchController = null;
+    }
   }
 }
 
@@ -146,19 +157,13 @@ function renderQueue(items) {
 
       // Combine episode progress with in-episode ffmpeg progress
       let ffPct = 0;
-      if (isRunning && lastFfmpegProgress.active && item.total_episodes > 0) {
+      if ((isRunning || isCancelling) && lastFfmpegProgress.active && item.total_episodes > 0) {
         ffPct = (lastFfmpegProgress.percent || 0) / item.total_episodes;
       }
       const combinedPct = Math.min(Math.round(epPct + ffPct), 100);
 
       let label;
-      if (isCancelling) {
-        label =
-          item.current_episode +
-          "/" +
-          item.total_episodes +
-          " episodes - finishing current episode...";
-      } else if (item.status === "cancelled") {
+      if (item.status === "cancelled" && !isCancelling) {
         label =
           item.current_episode +
           "/" +
@@ -175,6 +180,9 @@ function renderQueue(items) {
             "%" +
             (bw ? " @ " + bw : "") +
             ")";
+        }
+        if (isCancelling) {
+          epDetail += " - finishing current episode...";
         }
         label = epDetail;
       }
@@ -277,6 +285,11 @@ function renderQueue(items) {
         '<button class="queue-cancel" onclick="cancelQueueItem(' +
         item.id +
         ')" title="Cancel after current episode">Cancel</button>';
+    } else if (isCancelling) {
+      actionBtn =
+        '<button class="queue-cancel queue-force-cancel" style="background-color: #d32f2f;" onclick="forceCancelQueueItem(' +
+        item.id +
+        ')" title="Immediately kill download and delete partial files">Force Cancel</button>';
     }
 
     const userHtml = item.username
@@ -360,6 +373,24 @@ async function cancelQueueItem(id) {
     } else {
       if (typeof showToast === "function")
         showToast("Cancelling after current episode...");
+    }
+    loadQueue();
+  } catch (e) {
+    /* ignore */
+  }
+}
+
+async function forceCancelQueueItem(id) {
+  try {
+    const resp = await fetch("/api/queue/" + id + "/force_cancel", {
+      method: "POST",
+    });
+    const data = await resp.json();
+    if (data.error) {
+      if (typeof showToast === "function") showToast(data.error);
+    } else {
+      if (typeof showToast === "function")
+        showToast("Force cancelling download...");
     }
     loadQueue();
   } catch (e) {


### PR DESCRIPTION
Fixes the issue where the progress bar and details disappear when a download is cancelled in the Web UI. It also prevents multiple pending queue fetch requests from stacking. Finally, it adds a new 'Force Cancel' option to immediately abort the download and delete partial files.