### PR TITLE
fix: megakino search and verify kwarg

### DIFF
--- a/src/aniworld/config.py
+++ b/src/aniworld/config.py
@@ -152,7 +152,6 @@ GLOBAL_SESSION = Session(
     resolver=["doh+cloudflare://"],
     disable_http3=True,
     multiplexed=False,
-    verify=CA_CERT_BUNDLE,
     headers={
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         "Sec-Fetch-Site": "none",
@@ -165,6 +164,7 @@ GLOBAL_SESSION = Session(
         "Priority": "u=0, i",
     },
 )
+GLOBAL_SESSION.verify = CA_CERT_BUNDLE
 
 logger.debug("Config initialized successfully")
 logger.debug(

--- a/src/aniworld/search.py
+++ b/src/aniworld/search.py
@@ -16,7 +16,7 @@ SEARCH_URL = "https://aniworld.to/ajax/search"
 RANDOM_URL = "https://aniworld.to/ajax/randomGeneratorSeries"
 NEW_EPISODES_URL = "https://aniworld.to/neue-episoden"
 HOME_URL = "https://aniworld.to"
-MAX_PAGES = 5
+MAX_PAGES = 15
 
 _homepage_cache = None
 _megakino_homepage_cache = None


### PR DESCRIPTION
niquests.Session (like requests.Session) doesn't accept `verify` as an
__init__ argument — it has to be set as an attribute afterwards.
Was causing `TypeError: Session.__init__() got an unexpected keyword
argument 'verify'` on startup.

Increased `MAX_PAGES` for Megakino because this was causing #248: common search queries like "Film" can return a large number of pages. The F1 movie was listed on a page beyond the previous limit of 5, so it wasn't included in the results. This change increases search time for some queries, but I'm not sure if there's a better way to handle this.
