### PR TITLE
fix(web): add Cineby to custom path site options

### DIFF
--- a/src/aniworld/web/static/settings.js
+++ b/src/aniworld/web/static/settings.js
@@ -458,6 +458,7 @@ const PATH_SITE_OPTIONS = [
   ["filmpalast", "FilmPalast"],
   ["mangafire", "MangaFire"],
   ["htv", "Hanime"],
+  ["cineby", "Cineby"],
 ];
 
 function renderCustomPaths(paths) {


### PR DESCRIPTION
Added Cineby to the list of available sites in Custom Paths settings. This fixes the issue where Cineby could not be selected as a default for custom paths.