### PR TITLE
feat: make queue titles clickable

### DIFF
--- a/src/aniworld/web/static/queue.js
+++ b/src/aniworld/web/static/queue.js
@@ -346,7 +346,9 @@ function renderQueue(items) {
       '<div class="queue-item-header">' +
       '<div class="queue-item-title">' +
       syncBadge +
+      '<a href="' + escQ(item.series_url) + '" target="_blank" rel="noopener noreferrer" style="color: inherit; text-decoration: none;">' +
       escQ(item.title) +
+      '</a>' +
       "</div>" +
       '<div class="queue-item-right">' +
       statusBadge +

--- a/src/aniworld/web/templates/base.html
+++ b/src/aniworld/web/templates/base.html
@@ -70,7 +70,7 @@
   </div>
 
   <div class="toast" id="toast"></div>
-  <script src="{{ url_for('static', filename='queue.js') }}?v={{ app_version }}"></script>
+  <script src="{{ url_for('static', filename='queue.js') }}?v={{ app_version }}&cb=1"></script>
 
   <div class="captcha-overlay" id="captchaOverlay" onclick="if (event.target === this) closeCaptchaModal();">
     <div class="captcha-modal">


### PR DESCRIPTION
This PR makes the titles of the queue entries clickable and redirects to the series page in a new tab, matching the behavior of the download pop-up.