### PR TITLE
feat(webui): make queue item titles clickable links

### DIFF
--- a/src/aniworld/web/static/queue.js
+++ b/src/aniworld/web/static/queue.js
@@ -346,7 +346,9 @@ function renderQueue(items) {
       '<div class="queue-item-header">' +
       '<div class="queue-item-title">' +
       syncBadge +
+      '<a href="' + escQ(item.series_url) + '" target="_blank" rel="noopener noreferrer">' +
       escQ(item.title) +
+      '</a>' +
       "</div>" +
       '<div class="queue-item-right">' +
       statusBadge +

--- a/src/aniworld/web/static/style.css
+++ b/src/aniworld/web/static/style.css
@@ -1691,6 +1691,15 @@ h1 {
   min-width: 0;
 }
 
+.queue-item-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.queue-item-title a:hover {
+  text-decoration: underline;
+}
+
 .queue-item-right {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Diese Änderung fügt die Funktionalität hinzu, dass die Titel der Einträge im WebUI Queue-Fenster klickbar sind und den Nutzer auf die entsprechende Download-Seite weiterleiten (ähnlich wie im Download-Pop-up).