### PR TITLE
fix: Dynamic provider colors on mobile

### DIFF
--- a/src/aniworld/web/static/app.js
+++ b/src/aniworld/web/static/app.js
@@ -421,6 +421,10 @@ function updateSliderState(site) {
     if (label) label.classList.toggle("active", site === siteKey);
   }
 
+  const color = thumbColors[site] || thumbColors.aniworld;
+  document.documentElement.style.setProperty('--active-site-bg', color.bg);
+  document.documentElement.style.setProperty('--active-site-shadow', color.shadow);
+
   if (!segmentedThumb) return;
   const btn = document.getElementById(siteLabelIds[site]);
   if (!btn) return;
@@ -429,7 +433,6 @@ function updateSliderState(site) {
   const btnRect = btn.getBoundingClientRect();
   segmentedThumb.style.width = btnRect.width + "px";
   segmentedThumb.style.transform = "translateX(" + (btnRect.left - trackRect.left - 3) + "px)";
-  const color = thumbColors[site] || thumbColors.aniworld;
   segmentedThumb.style.background = color.bg;
   segmentedThumb.style.boxShadow = color.shadow;
 }

--- a/src/aniworld/web/static/style.css
+++ b/src/aniworld/web/static/style.css
@@ -2403,8 +2403,8 @@ h1 {
   }
 
   .segmented-btn.active {
-    background: linear-gradient(135deg, #9333ea, #7c3aed);
-    box-shadow: 0 2px 8px rgba(147, 51, 234, 0.35);
+    background: var(--active-site-bg, linear-gradient(135deg, #9333ea, #7c3aed));
+    box-shadow: var(--active-site-shadow, 0 2px 8px rgba(147, 51, 234, 0.35));
   }
 
   .settings-container,


### PR DESCRIPTION
Replaced hardcoded purple gradient in mobile styles with CSS variables
(--active-site-bg and --active-site-shadow) dynamically set by JS
for the active provider.
