### PR TITLE
fix(serienstream): apply mirror handling to every known s.to host

### DIFF
--- a/src/aniworld/config.py
+++ b/src/aniworld/config.py
@@ -413,7 +413,26 @@ HANIME_TV_SERIES_PATTERN = re.compile(
 )
 
 # serienstream.to went down at times; serienstream.cx and 186.2.175.5 are mirrors.
-_STO_HOST = r"(?:(?:www\.)?(?:serienstream\.(?:to|cx)|s\.to)|186\.2\.175\.5)"
+
+# Reachable hosts, in preference order. The IP is a last resort and needs a Host
+# header (see models/s_to/http.py) because it serves the same site.
+STO_DOMAINS = ["serienstream.to", "serienstream.cx"]
+STO_IP = "186.2.175.5"
+
+# Retired hosts that are still recognised and rewritten onto an active host, but
+# never requested themselves. Keeps old links and bookmarks working.
+STO_LEGACY_DOMAINS = ["s.to"]
+
+STO_ALL_HOSTS = [*STO_DOMAINS, STO_IP, *STO_LEGACY_DOMAINS]
+
+_STO_HOST = r"(?:www\.)?(?:" + "|".join(re.escape(h) for h in STO_ALL_HOSTS) + r")"
+
+STO_HOST_RE = re.compile(r"^(https?://)" + _STO_HOST + r"(?=[:/?#]|$)", re.IGNORECASE)
+
+def is_sto_host(url):
+    """True if the URL points at any known serienstream host."""
+    return bool(STO_HOST_RE.match(str(url or "")))
+
 
 SERIENSTREAM_SERIES_PATTERN = re.compile(
     rf"^https?://{_STO_HOST}/serie/[a-zA-Z0-9\-]+/?$", re.IGNORECASE

--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -28,6 +28,7 @@ try:
         Audio,
         Subtitles,
         get_video_codec,
+        is_sto_host,
         logger,
     )
 except ImportError:
@@ -41,6 +42,7 @@ except ImportError:
         Audio,
         Subtitles,
         get_video_codec,
+        is_sto_host,
         logger,
     )
 
@@ -1071,8 +1073,8 @@ def download(self):
                     header_list = [f"{k}: {v}" for k, v in headers.items()]
                     input_kwargs["headers"] = "\r\n".join(header_list) + "\r\n"
 
-                url = (getattr(self, "url", "") or "").lower()
-                is_serienstream = ("serienstream.to" in url) or ("s.to" in url)
+                # Covers every host in config.STO_DOMAINS/STO_IP
+                is_serienstream = is_sto_host(getattr(self, "url", "") or "")
 
                 if is_serienstream and hasattr(self, "_normalize_language"):
                     audio_enum, sub_enum = self._normalize_language(

--- a/src/aniworld/models/s_to/http.py
+++ b/src/aniworld/models/s_to/http.py
@@ -7,28 +7,19 @@ reused, and any serienstream URL is rewritten to it so pages, redirect links
 and stream resolution all stay on the same working host.
 """
 
-import re
 import warnings
 
 from urllib3.exceptions import InsecureRequestWarning
 
 try:
-    from ...config import GLOBAL_SESSION
+    from ...config import GLOBAL_SESSION, STO_DOMAINS, STO_HOST_RE, STO_IP
 except ImportError:
-    from aniworld.config import GLOBAL_SESSION
+    from aniworld.config import GLOBAL_SESSION, STO_DOMAINS, STO_HOST_RE, STO_IP
 
 warnings.simplefilter("ignore", InsecureRequestWarning)
 
-# Reachable hosts, in preference order. The IP is a last resort and needs a
-# Host header (handled below) because it serves the same site.
-STO_DOMAINS = ["serienstream.to", "serienstream.cx"]
-STO_IP = "186.2.175.5"
-
-# Match any known serienstream host so URLs can be rewritten to the active one.
-_HOST_RE = re.compile(
-    r"^(https?://)(?:www\.)?(?:serienstream\.(?:to|cx)|s\.to|186\.2\.175\.5)",
-    re.IGNORECASE,
-)
+# Host list lives in config.py, add a mirror there
+_HOST_RE = STO_HOST_RE
 
 _active_idx = 0
 


### PR DESCRIPTION
### Problem
The checks that gate serienstream specific behaviour never
learned about the mirrors:

```
# models/common/common.py
url = (getattr(self, "url", "") or "").lower()
is_serienstream = ("serienstream.to" in url) or ("s.to" in url)
```


### Fix
The host list moves to `config.py` and everything is sourced from there:
```
STO_DOMAINS = ["serienstream.to", "serienstream.cx"]
STO_IP = "186.2.175.5"
STO_LEGACY_DOMAINS = ["s.to"]   # recognised and rewritten, never requested
```
