### PR TITLE
DubSync: graft a web dub onto local files, and fix multi-language sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Full guides and troubleshooting live in the [documentation](https://www.phoenixt
 - Manage a library from the Web UI
 - Protect the Web UI with local accounts or OIDC SSO
 - Accept download requests through the optional Discord bot
+- Graft a German dub onto your own archive-quality video files with DubSync
 - Run locally, in Docker, or as a standalone build
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -100,6 +101,100 @@ Full guides and troubleshooting live in the [documentation](https://www.phoenixt
 | MegaKino | Broken | 07/26 |
 
 Availability depends on the selected site and episode. When a provider fails, the downloader can try the others in your configured fallback order. These are third-party services, so availability can change without warning.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## DubSync
+
+You have high-quality Blu-ray rips that only carry Japanese/English audio, and
+AniWorld has the German dub? DubSync extracts the dub audio from the stream and
+losslessly muxes it into each matching local file as a secondary,
+`deu`-tagged audio track — video and existing audio are never re-encoded.
+
+```sh
+# 1) Dry run: see which local files match which episodes and the detected
+#    audio offsets, without writing anything
+aniworld https://aniworld.to/anime/stream/<series>/staffel-1 \
+  --dubsync-target ~/Anime/MyShow/Season01 --dubsync-dry-run
+
+# 2) Real run: writes <name>.dubsync.mkv next to each file (originals untouched)
+aniworld https://aniworld.to/anime/stream/<series>/staffel-1 \
+  --dubsync-target ~/Anime/MyShow/Season01
+```
+
+- **Automatic alignment** – the dub's offset against each file is detected by
+  correlating the shared music/SFX bed (works even though the dialogue differs).
+  Low-confidence detections fall back to offset 0 and are flagged for manual
+  verification. Use `--dubsync-offset <seconds>` to force a manual offset.
+  See [docs/dubsync-alignment.md](docs/dubsync-alignment.md) for how the
+  alignment algorithm works.
+- **Drift correction** – PAL-sourced dubs run ~4% fast, which a constant offset
+  can't fix. `--dubsync-allow-resample` corrects the drift with `atempo`
+  (re-encodes only the dub track; opt-in because it sacrifices bit-exactness).
+- **In-place mode** – `--dubsync-cleanup` replaces the originals
+  (temp + atomic swap) instead of writing `.dubsync.mkv` copies.
+- Files that already carry the dub language are skipped automatically; matching
+  handles common scene/Blu-ray naming (`Show - 01`, `S01E01`, `01v2`, …) and
+  reports unmatched files instead of guessing.
+- Also available in the Web UI: the **DubSync** tab lets you browse to your
+  local folder, search the show, and queue the job with the matching episodes
+  auto-selected from your filenames. Defaults live on the Settings page; see
+  the `ANIWORLD_DUBSYNC_*` keys in `.env.example` for persistent
+  configuration.
+- **Movies too** – a show's "Filme" collection appears as its own *Movies*
+  section, and the site selector also offers MegaKino/FilmPalast for
+  standalone films. Movie filenames carry no episode numbers, so each movie
+  gets a dropdown to confirm its local file (best title match pre-selected).
+
+### Multi-language downloads
+
+Downloading the same episode again with another `-l` language adds it to the
+existing file as an extra audio track. The new track's timing offset against
+the file is detected with the DubSync aligner and applied during the merge, so
+both languages stay in sync (previously the second track could play late).
+Disable with `--no-merge-align` / `ANIWORLD_MERGE_ALIGN=0`; unconfident
+detections automatically fall back to the plain merge.
+
+German TV dubs are usually PAL (25 fps) where the original-language encode is
+film rate (23.976), so they run ~4 % fast — a difference no constant offset can
+fix. When that is detected, the added track is retimed to match instead
+(re-encoded; the existing streams are never touched). `--no-merge-resample`
+turns that off and merges unshifted.
+
+"Sub" variants (e.g. *German Sub*) are hardsubbed video encodes, not subtitle
+tracks — they are merged into the same file as an additional, non-default
+video track (plus their audio), also time-aligned, so one MKV holds every
+version and you switch tracks in your player. Prefer separate per-language
+files? Put `{language}` into your naming template.
+
+> **Note:** a second video track works in mpv and VLC, but media servers
+> generally ignore it — Jellyfin will only ever play the first video track,
+> so a hardsubbed variant is not reachable there. If you use a media server,
+> either give sub variants their own file via `{language}` in the naming
+> template, or use `--fetch-subs` below, which produces a real subtitle track
+> every player understands. Extra *audio* tracks are picked up everywhere.
+
+### Real subtitle tracks (`--fetch-subs`)
+
+Since the streaming hosters only serve hardsubbed video, togglable subtitles
+are fetched externally: Erai-raws MultiSub releases carry the official
+Crunchyroll subtitles (German included), and Animetosho serves each extracted
+subtitle individually without any API key.
+
+```sh
+aniworld -l "German Dub" --fetch-subs <episode-url>   # German subs (default)
+aniworld -l "German Dub" --fetch-subs eng <url>       # or another language
+```
+
+After each download the episode's season is resolved to its MyAnimeList entry
+(same mapping AniSkip uses), the matching Erai-raws release is looked up on
+Animetosho, and the subtitle is muxed in as a non-default, language-tagged
+track (MKV) or written as a `.ger.ass` sidecar (other containers). Anime only;
+roughly 2020+ shows — older seasons predate Erai-raws' German subs. If
+[ffsubsync](https://github.com/smacke/ffsubsync) is installed
+(`pip install ffsubsync`), the subtitle is time-aligned to your file first.
+Set `ANIWORLD_FETCH_SUBS=ger` to enable it permanently (Web UI queue
+downloads inherit it too).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/docs/dubsync-alignment.md
+++ b/docs/dubsync-alignment.md
@@ -181,6 +181,15 @@ a **"Sub" variant is never retimed at all** — its audio arrived with its own
 video, so speeding up one without the other would desync them; that case is
 merged unshifted with a warning instead.
 
+### Player support for the appended streams
+
+Extra **audio** tracks are understood everywhere. An extra **video** track (a
+hardsubbed "Sub" variant) is not: mpv and VLC switch between them fine, but
+media servers generally play only the first video track — Jellyfin will not
+surface the second one at all. Users on a media server should either separate
+sub variants into their own files (`{language}` in the naming template) or use
+`--fetch-subs`, which yields a real subtitle track instead.
+
 ## Design notes
 
 * The interface is a single pluggable call:

--- a/docs/dubsync-alignment.md
+++ b/docs/dubsync-alignment.md
@@ -1,0 +1,203 @@
+# DubSync: How the Automatic Audio Alignment Works
+
+DubSync grafts a web-sourced German dub onto an archive-quality video file
+(e.g. a Blu-ray rip that only carries JP/EN audio). Before the dub can be
+muxed in, its timing has to match the target video — different releases trim
+intros differently, add black frames, or run at a different speed entirely.
+This document explains how the aligner
+([`align.py`](../src/aniworld/models/aniworld_to/dubsync/align.py)) detects
+those differences automatically.
+
+## The problem
+
+The obvious approach — correlate the two audio tracks directly — cannot work:
+the dialogue is *different speech in different languages*. What both tracks
+share is the **music and sound-effects bed**: a door slam, an explosion, or a
+musical sting happens at the same story moment in every language version of an
+episode. The aligner is built entirely around locking onto that shared signal.
+
+Two kinds of misalignment occur in practice:
+
+| Kind | Cause | Fix |
+| --- | --- | --- |
+| **Constant offset** | Different intro/pre-roll trimming, black frames | Delay the dub by a fixed amount (`-itsoffset`, lossless) |
+| **Linear drift** | PAL-sourced dubs run 25/23.976 ≈ 4.3 % fast, so the offset grows over the episode | Retime the dub (`atempo`, re-encodes the dub track only — opt-in) |
+
+## Step 1 — Onset envelopes
+
+Both tracks are decoded to mono 8 kHz PCM with ffmpeg. For the target video,
+the Japanese audio stream is preferred as the reference (falling back to the
+first audio stream) — though the method does not depend on the language, since
+the signal being matched is the non-dialogue bed.
+
+Each track is then collapsed into an **onset envelope**:
+
+1. Chop the samples into 10 ms frames (100 frames per second).
+2. Reduce each frame to its RMS energy, log-compressed: `log(1 + 100·rms)`.
+3. Take the frame-to-frame *difference* and clip negative values to zero
+   (half-wave rectification), keeping only "it suddenly got louder" events.
+4. Z-normalise the result.
+
+The output is a spiky 100 Hz signal dominated by loud transients — music hits
+and SFX — while continuous speech contributes only small ripples. That is what
+makes the envelope nearly identical between the dub and the original even
+though every spoken word differs.
+
+## Step 2 — FFT cross-correlation
+
+Finding the constant offset means asking: *if the dub's envelope is slid by
+`X` seconds, how well do its spikes line up with the reference's spikes?* —
+for every possible `X`. Computed naively this is O(n²); via the correlation
+theorem it is two FFTs and a multiply:
+
+```
+corr = irfft( rfft(ref_env) · conj(rfft(dub_env)) )
+```
+
+`corr[k]` is the match score for delaying the dub by `k` envelope samples
+(negative lags wrap around and mean "advance the dub"). The search is bounded
+to ±600 s by default. The best lag is refined below the 10 ms envelope
+resolution by parabolic interpolation over the peak and its two neighbours.
+
+For a 24-minute episode the envelopes are ~145 000 samples, so the whole
+correlation takes milliseconds.
+
+## Step 3 — Confidence as a z-score
+
+The raw peak height is meaningless on its own, so it is converted into a
+z-score: how many standard deviations the peak rises above the rest of the
+searched correlation range (excluding ±1 s around the peak itself).
+
+* A genuine match is a needle: z ≫ 10, often in the hundreds.
+* Two unrelated tracks produce a mushy landscape whose tallest bump is only
+  z ≈ 3–5.
+
+The default acceptance threshold is **z ≥ 8** (`DEFAULT_MIN_CONFIDENCE`).
+Below it, the pipeline does not trust the detection: the episode falls back to
+offset 0 (or the user's manual `--dubsync-offset`) and is flagged
+*low-confidence* in the report so it can be verified by ear.
+
+## Step 4 — Drift detection by tempo scanning
+
+A speed-changed dub breaks the constant-offset model *and* sabotages the
+correlation itself: each music hit wants a slightly different lag, so the peak
+smears out (a 4 % PAL drift spreads it over ±30 s and the confidence collapses
+into the noise floor).
+
+The scan turns that symptom into the detector. The dub envelope is
+time-stretched by candidate speed factors and re-correlated at each one:
+
+* At the **wrong** tempo the peak stays smeared and flat.
+* At the **true** tempo every hit snaps to the same lag and the peak becomes
+  dramatically sharp.
+
+The search is hierarchical over `1 ± 6 %` (covering PAL ↔ film both ways with
+headroom): a coarse grid at step 2·10⁻³, then finer grids of 2·10⁻⁴ and
+2·10⁻⁵ around the running best — roughly a hundred correlations total, each
+against a precomputed reference FFT. The final step bounds the tempo error at
+~10⁻⁵, i.e. ~14 ms of residual drift over a 24-minute episode. On synthetic
+PAL material the scan recovers 25/23.976 to five decimal places.
+
+Guard rails, in order:
+
+1. Only attempted when the dub is ≥ 5 minutes (`_DRIFT_MIN_DURATION`) —
+   shorter material cannot distinguish drift from noise.
+2. A non-identity tempo must clear the normal confidence threshold **and**
+   beat the identity-tempo peak by a margin of 5 z (`_TEMPO_MARGIN`).
+   Random noise cannot fake that, because real drift *un-smears* the peak
+   rather than just nudging it.
+3. The resulting drift must exceed 0.2 s across the episode
+   (`DRIFT_THRESHOLD`) before it is reported at all.
+
+When drift is confirmed, the result carries the `atempo` factor
+(`tempo_ratio = 1/detected speed`) and the residual constant offset measured
+at the winning tempo (`post_tempo_offset`).
+
+## Step 5 — Applying the result
+
+* **Constant offset only** (the common case): the dub is muxed with
+  `-itsoffset <offset>` and `-c copy` — fully lossless, the dub stream stays
+  bit-exact.
+* **Drift detected**: correction requires `atempo`, which must decode and
+  re-encode the dub audio. Because that sacrifices bit-exactness of the dub
+  track, it only runs when the user opts in (`--dubsync-allow-resample`); the
+  re-encode goes to FLAC so no further generational loss occurs after the
+  unavoidable decode. Video and all original audio remain untouched either
+  way. Without the opt-in, the constant offset is used and the episode is
+  flagged that sync may wander.
+
+`aniworld <url> --dubsync-target <dir> --dubsync-dry-run` runs match +
+alignment for every episode and prints the detected offsets, confidences and
+drift **without writing to any target file** — the recommended way to build
+trust in the aligner before it touches archive files.
+
+## Reuse: multi-language downloads
+
+The same detector runs outside DubSync. Downloading an episode you already have
+in another language merges the new stream into the existing file, and the
+streams come from different hoster encodes that rarely start at the same
+instant — so the merge asks `detect_offset` for the shift first instead of
+concatenating blindly (which is what used to leave the second track playing
+late).
+
+* An extra **dub** becomes another audio track, muxed through the same
+  `-itsoffset` + `-c copy` path DubSync uses.
+* A hardsubbed **"Sub" variant** brings its own video, so its video and audio
+  are appended as one unit shifted by a single offset — they are already in
+  sync with each other, only with the file as a whole.
+
+Both cases mark the appended streams non-default so players keep the original
+primary, and both fall back to an unshifted merge when the detection lands
+below `DEFAULT_MIN_CONFIDENCE` — the alignment is an improvement on the old
+behaviour, never a precondition for the download succeeding.
+`--no-merge-align` (or `ANIWORLD_MERGE_ALIGN=0`) opts out entirely.
+
+The search is bounded to ±60 s here rather than the ±600 s default: two
+encodes of the same episode start within seconds of each other, and a wider
+window only lets a noise peak minutes away win.
+
+### Speed mismatches are retimed, never shifted
+
+Drift is not a corner case on this path — it is the *norm* for German TV dubs,
+which are PAL (25 fps) while the original-language encode is film rate
+(23.976), so the two run ~4.3 % apart. Observed live on Family Guy S01E01:
+the identity-tempo peak was noise (z=4.1, claiming a −13 s offset) while the
+tempo scan locked onto exactly 0.95904 at z=19.5.
+
+That combination is a trap, because `detect_offset` overwrites
+`result.confidence` with the *drift* confidence while `result.offset` keeps
+the identity-tempo value. Reading the two together says "high confidence,
+apply this offset" about a number that was measured at noise level — which is
+how a merge once placed a track 95 s late. **When `has_drift` is set, the
+constant offset must be ignored**; only `post_tempo_offset` is meaningful, and
+only after the audio has actually been retimed.
+
+So the download path retimes rather than shifts: `resample_dub` applies the
+`atempo` factor to the added track (re-encoded to AAC here, not FLAC, since
+the source is an already-lossy stream rip and a lossless track would dwarf the
+video), then the residual `post_tempo_offset` is applied as usual. Only the
+freshly added track is ever re-encoded. `--no-merge-resample` disables it, and
+a **"Sub" variant is never retimed at all** — its audio arrived with its own
+video, so speeding up one without the other would desync them; that case is
+merged unshifted with a warning instead.
+
+## Design notes
+
+* The interface is a single pluggable call:
+  `detect_offset(dub_path, ref_path) -> AlignResult(offset, confidence, drift,
+  tempo_ratio, …)` — the correlation implementation can be swapped without
+  touching the pipeline.
+* Only **numpy** is required (`rfft`/`irfft`); no scipy, no fingerprinting
+  libraries.
+* End-to-end analysis cost is ~2 s per episode: everything after decoding
+  operates on 100 Hz envelopes, not raw audio.
+* The technique is the same family as [ffsubsync](https://github.com/smacke/ffsubsync)
+  uses for subtitle alignment, adapted to audio-vs-audio with the tempo scan
+  added for speed-changed dubs.
+* Unit tests ([`tests/test_dubsync_align.py`](../tests/test_dubsync_align.py))
+  synthesise impulse-bed signals with known shifts, PAL-speed drift, and
+  uncorrelated noise, asserting recovered offsets/tempi and that noise stays
+  below the confidence threshold.
+  [`tests/test_multilang_merge.py`](../tests/test_multilang_merge.py) covers
+  the download-path reuse end to end: a deliberately delayed second language
+  must come back aligned, tagged and non-default, in a single file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "cryptography",                                                             # !=3.9.0, !=3.9.1, >=3.9
   "patchright",                                                               # >=3.9
   "curl_cffi",                                                                # TLS impersonation for Cloudflare-gated hosters (VOE)
+  "numpy",                                                                    # DubSync audio alignment (FFT cross-correlation)
   'windows-curses<3.14; sys_platform == "win32" and python_version < "3.14"', # ??? - npyscreen on Windows
 ]
 

--- a/src/aniworld/.env.example
+++ b/src/aniworld/.env.example
@@ -249,6 +249,90 @@ ANIWORLD_SYNC_PROVIDER=VOE
 
 
 # ==============================
+# DubSync Settings
+# ==============================
+# DubSync grafts a web-sourced dub (e.g. German) from AniWorld/SerienStream
+# losslessly onto local archive-quality videos (e.g. Blu-ray rips) as a
+# secondary, language-tagged audio track.
+# CLI: aniworld <series/season-url> --dubsync-target <dir> [--dubsync-dry-run]
+
+# Default target directory of local videos (used by the Web UI enqueue form;
+# the CLI --dubsync-target flag always takes precedence).
+ANIWORLD_DUBSYNC_TARGET_DIR=
+
+# Manual dub delay in seconds (may be negative, e.g. -1.5).
+# Leave empty to use automatic alignment.
+ANIWORLD_DUBSYNC_OFFSET=
+
+# Detect each episode's offset automatically via music/SFX-bed correlation.
+# 0 = off, 1 = on
+ANIWORLD_DUBSYNC_AUTO_ALIGN=1
+
+# Correct linear drift (e.g. PAL-speed dubs, ~4% fast) via atempo.
+# This re-encodes the dub audio track only; video and original audio stay
+# untouched. 0 = off, 1 = on
+ANIWORLD_DUBSYNC_ALLOW_RESAMPLE=0
+
+# Edit target files in place (temp + atomic replace) instead of writing
+# *.dubsync.mkv copies next to them. 0 = off, 1 = on
+ANIWORLD_DUBSYNC_CLEANUP=0
+
+# Which audio language to graft from the source.
+# Options: German Dub | English Dub
+ANIWORLD_DUBSYNC_AUDIO_LANG=German Dub
+
+
+# ==============================
+# Multi-Language Downloads
+# ==============================
+# Downloading an episode you already have in another language adds the new
+# language to the SAME file: an extra dub becomes another audio track, and a
+# hardsubbed "Sub" variant is appended as a second video+audio pair. Appended
+# streams are marked non-default, so players keep the original primary.
+
+# Line the added track up with the file it is merged into, using the same
+# music/SFX-bed correlation DubSync uses. Without this the added track can
+# play seconds late, because hoster encodes rarely start at the same instant.
+# A low-confidence detection falls back to an unshifted merge on its own.
+# CLI: --merge-align / --no-merge-align. 0 = off, 1 = on
+ANIWORLD_MERGE_ALIGN=1
+
+# German TV dubs are usually PAL (25 fps) where the original-language encode
+# is film rate (23.976), so they run ~4% fast -- a difference no constant
+# offset can fix. When that is detected, retime the added track to match.
+# Re-encodes ONLY the freshly added track; existing streams stay untouched.
+# A "Sub" variant is never retimed (its audio came with its own video).
+# CLI: --merge-resample / --no-merge-resample. 0 = off, 1 = on
+ANIWORLD_MERGE_RESAMPLE=1
+
+
+# ==============================
+# Subtitle Fetching
+# ==============================
+# The hosters only serve hardsubbed video, so a real (togglable) subtitle
+# track has to come from elsewhere: Erai-raws MultiSub releases carry the
+# official Crunchyroll subtitles, and Animetosho serves each extracted
+# subtitle individually (no API key needed).
+#
+# After a download the episode's season is resolved to its MyAnimeList entry
+# (the mapping AniSkip already uses) to get the romaji title scene releases
+# are named after, then the subtitle is muxed in as a non-default,
+# language-tagged track -- or written as a sidecar file for containers that
+# cannot hold ASS (e.g. MP4).
+#
+# Anime only, and roughly 2020+ for German: older seasons predate Erai-raws'
+# German subs. A miss is logged and the download completes normally.
+#
+# Set to a language to enable: ger | eng | fre | spa | ita | por | rus | ara
+# Empty or 0 = off. CLI: --fetch-subs [LANG] (defaults to ger)
+ANIWORLD_FETCH_SUBS=
+
+# Optional: install ffsubsync (pip install ffsubsync) to time-align the
+# fetched subtitle against your own file instead of trusting the release's
+# timing. Used automatically when present, skipped with a log note when not.
+
+
+# ==============================
 # FFmpeg & Encoding Settings
 # ==============================
 

--- a/src/aniworld/aniskip/jikan.py
+++ b/src/aniworld/aniskip/jikan.py
@@ -23,16 +23,23 @@ def search_jikan(query, sfw=False, limit=5):
         "order_by": "popularity",
         "sort": "asc",  # earliest / most popular first
     }
-    try:
-        logger.debug(
-            f"Searching Jikan API URL: {JIKAN_SEARCH_URL} with params: {params}"
-        )
-        res = GLOBAL_SESSION.get(JIKAN_SEARCH_URL, params=params)
-        res.raise_for_status()
-        return res.json().get("data", [])
-    except Exception as e:
-        logger.error(f"Error searching Jikan API for query '{query}': {e}")
-        return []
+    # Jikan is a community-run mirror and regularly answers 5xx under load;
+    # one retry rescues most lookups.
+    for attempt in range(2):
+        try:
+            logger.debug(
+                f"Searching Jikan API URL: {JIKAN_SEARCH_URL} with params: {params}"
+            )
+            res = GLOBAL_SESSION.get(JIKAN_SEARCH_URL, params=params)
+            res.raise_for_status()
+            return res.json().get("data", [])
+        except Exception as e:
+            if attempt == 0:
+                logger.debug(f"Jikan search failed ({e}); retrying once...")
+                time.sleep(2)
+                continue
+            logger.error(f"Error searching Jikan API for query '{query}': {e}")
+    return []
 
 
 # Caches to avoid repeated API calls
@@ -109,6 +116,32 @@ def get_all_related_ids(season1_id):
                         stack.append(anime_id)
 
     return collected
+
+
+def get_anime_titles(mal_id):
+    """Return the known titles of a MAL anime, most canonical first.
+
+    The romaji "Default" title comes first because scene releases
+    (e.g. Erai-raws) name their files after it; English and synonym titles
+    follow as search fallbacks.
+    """
+    try:
+        logger.debug(f"Fetching titles for MAL ID: {mal_id}")
+        res = GLOBAL_SESSION.get(JIKAN_ANIME_URL.format(id=mal_id))
+        res.raise_for_status()
+        data = res.json().get("data", {})
+        titles = []
+        for wanted in ("Default", "English", "Synonym"):
+            for entry in data.get("titles", []):
+                title = (entry.get("title") or "").strip()
+                if entry.get("type") == wanted and title and title not in titles:
+                    titles.append(title)
+        logger.debug(f"Waiting to respect Jikan API rate limits... {API_DELAY}s")
+        time.sleep(API_DELAY)
+        return titles
+    except Exception as e:
+        logger.error(f"Error fetching titles for MAL ID {mal_id}: {e}")
+        return []
 
 
 def get_all_seasons_by_query(query="love is war"):

--- a/src/aniworld/arguments.py
+++ b/src/aniworld/arguments.py
@@ -166,6 +166,36 @@ def parse_args():
         "--output",
         help="Output file path",
     )
+    playback.add_argument(
+        "--merge-align",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "When adding a second language to an already downloaded episode, "
+            "detect its timing offset and merge it in sync (default: on)"
+        ),
+    )
+    playback.add_argument(
+        "--merge-resample",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Retime an extra language that runs at a different speed (PAL dubs "
+            "run ~4%% fast), which a constant offset cannot fix. Re-encodes "
+            "only the added track (default: on)"
+        ),
+    )
+    playback.add_argument(
+        "--fetch-subs",
+        nargs="?",
+        const="ger",
+        metavar="LANG",
+        help=(
+            "After a download, fetch a real (soft) subtitle track for the "
+            "episode from Erai-raws releases via Animetosho and mux it in "
+            "(anime only; LANG defaults to 'ger' for German)"
+        ),
+    )
 
     # =========================
     # Discovery / Random
@@ -275,6 +305,67 @@ def parse_args():
     )
 
     # =========================
+    # DubSync (graft a web dub onto local archive-quality videos)
+    # =========================
+    dubsync = parser.add_argument_group(
+        "DubSync Options (graft a German dub onto local video files)"
+    )
+    dubsync.add_argument(
+        "-dt",
+        "--dubsync-target",
+        metavar="DIR",
+        help=(
+            "Directory of local (e.g. Blu-ray) videos to enrich with the dub "
+            "audio of the given AniWorld/SerienStream URL. Enables DubSync mode."
+        ),
+    )
+    dubsync.add_argument(
+        "-dO",
+        "--dubsync-offset",
+        type=float,
+        metavar="SECONDS",
+        help=(
+            "Manual dub delay in seconds (negative allowed). "
+            "Overrides automatic alignment."
+        ),
+    )
+    dubsync.add_argument(
+        "--dubsync-auto-align",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Detect the dub offset per episode automatically (default: on)",
+    )
+    dubsync.add_argument(
+        "--dubsync-allow-resample",
+        action="store_true",
+        help=(
+            "Correct linear drift (e.g. PAL-speed dubs) via atempo. "
+            "Re-encodes the dub track only; everything else stays lossless."
+        ),
+    )
+    dubsync.add_argument(
+        "--dubsync-cleanup",
+        action="store_true",
+        help=(
+            "Edit target files in place (temp + atomic replace) instead of "
+            "writing *.dubsync.mkv copies next to them"
+        ),
+    )
+    dubsync.add_argument(
+        "--dubsync-recursive",
+        action="store_true",
+        help="Scan the target directory recursively",
+    )
+    dubsync.add_argument(
+        "--dubsync-dry-run",
+        action="store_true",
+        help=(
+            "Print the match report and detected offsets without writing "
+            "to any target file"
+        ),
+    )
+
+    # =========================
     # Syncplay (only meaningful with --action Syncplay)
     # =========================
     syncplay = parser.add_argument_group(
@@ -346,6 +437,15 @@ def parse_args():
         logger.debug(f"Anime4K upscaling set to: {mode}")
         anime4k(mode)
 
+    if not args.merge_align:
+        os.environ["ANIWORLD_MERGE_ALIGN"] = "0"
+
+    if not args.merge_resample:
+        os.environ["ANIWORLD_MERGE_RESAMPLE"] = "0"
+
+    if args.fetch_subs:
+        os.environ["ANIWORLD_FETCH_SUBS"] = args.fetch_subs
+
     if args.debug:
         os.environ["ANIWORLD_DEBUG_MODE"] = "1"
 
@@ -354,6 +454,20 @@ def parse_args():
             logging.getLogger(name).setLevel(logging.DEBUG)
 
         logger.debug("Debug mode enabled")
+
+    if args.dubsync_target:
+        os.environ["ANIWORLD_DUBSYNC_TARGET_DIR"] = os.path.abspath(
+            args.dubsync_target
+        )
+        if args.dubsync_offset is not None:
+            os.environ["ANIWORLD_DUBSYNC_OFFSET"] = str(args.dubsync_offset)
+        os.environ["ANIWORLD_DUBSYNC_AUTO_ALIGN"] = (
+            "1" if args.dubsync_auto_align else "0"
+        )
+        if args.dubsync_allow_resample:
+            os.environ["ANIWORLD_DUBSYNC_ALLOW_RESAMPLE"] = "1"
+        if args.dubsync_cleanup:
+            os.environ["ANIWORLD_DUBSYNC_CLEANUP"] = "1"
 
     if args.action == "Syncplay":
         if args.syncplay_host:

--- a/src/aniworld/entry.py
+++ b/src/aniworld/entry.py
@@ -42,6 +42,72 @@ def validate_action(action: str):
         raise ValueError(f"Invalid action: {action}")
 
 
+def _run_dubsync_cli(args) -> int:
+    """Handle ``--dubsync-target``: graft the URL's dub onto local files."""
+    from .models.aniworld_to.dubsync.pipeline import (
+        dubsync_env_defaults,
+        run_dubsync,
+    )
+
+    if len(args.url) != 1:
+        print(
+            "DubSync needs exactly one AniWorld/SerienStream series or "
+            "season URL as the positional argument.",
+            file=sys.stderr,
+        )
+        return 1
+
+    url = args.url[0].replace("://s.to", "://serienstream.to")
+    try:
+        provider = resolve_provider(url)
+    except Exception:
+        provider = None
+    is_series = bool(
+        provider
+        and provider.series_pattern
+        and provider.series_pattern.fullmatch(url)
+    )
+    is_season = bool(
+        provider
+        and provider.season_pattern
+        and provider.season_pattern.fullmatch(url)
+    )
+    if (
+        provider is None
+        or provider.name not in ("AniWorld", "SerienStream")
+        or not (is_series or is_season)
+    ):
+        print(
+            f"DubSync requires an AniWorld/SerienStream series or season URL, "
+            f"got: {url}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not os.path.isdir(args.dubsync_target):
+        print(
+            f"DubSync target is not a directory: {args.dubsync_target}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # The CLI flags were exported to ANIWORLD_DUBSYNC_* by parse_args, so the
+    # env defaults already reflect them (and .env supplies the rest).
+    defaults = dubsync_env_defaults()
+    _, outcomes = run_dubsync(
+        url,
+        args.dubsync_target,
+        offset=defaults["offset"],
+        audio_language=defaults["audio_language"],
+        recursive=args.dubsync_recursive,
+        dry_run=args.dubsync_dry_run,
+        cleanup=defaults["cleanup"],
+        auto_align=defaults["auto_align"],
+        allow_resample=defaults["allow_resample"],
+    )
+    return 1 if any(o.status == "failed" for o in outcomes) else 0
+
+
 def run_action(obj, action: str):
     validate_action(action)
     getattr(obj, action)()
@@ -59,6 +125,9 @@ def aniworld():
             logger.debug("Checking dependencies...")
             ensure_patchright_chromium()
             logger.debug("Dependencies OK")
+
+        if args.dubsync_target:
+            return _run_dubsync_cli(args)
 
         if args.web_ui:
             from .web import start_web_ui

--- a/src/aniworld/models/aniworld_to/dubsync/__init__.py
+++ b/src/aniworld/models/aniworld_to/dubsync/__init__.py
@@ -1,0 +1,27 @@
+"""DubSync: graft a web-sourced German dub onto archive-quality video files.
+
+``run_dubsync`` is exported lazily so that importing the pure-stdlib
+:mod:`matcher` (and its unit tests) does not pull in ffmpeg / config.
+"""
+
+from .matcher import MatchReport, match_directory
+
+__all__ = [
+    "run_dubsync",
+    "match_directory",
+    "MatchReport",
+    "detect_offset",
+    "AlignResult",
+]
+
+
+def __getattr__(name):
+    if name == "run_dubsync":
+        from .pipeline import run_dubsync
+
+        return run_dubsync
+    if name in ("detect_offset", "AlignResult"):
+        from . import align
+
+        return getattr(align, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/aniworld/models/aniworld_to/dubsync/align.py
+++ b/src/aniworld/models/aniworld_to/dubsync/align.py
@@ -1,0 +1,376 @@
+"""Automatic audio alignment between a dub track and a target's own audio.
+
+The dub and the target carry *different dialogue* (German vs JP/EN), so speech
+cannot be correlated directly. What both share is the music/SFX bed: loud
+musical hits and effects dominate an onset-energy envelope regardless of the
+spoken language. Cross-correlating those envelopes (via FFT) locks onto the
+shared bed and yields the constant offset between the two tracks; the peak's
+sharpness (a z-score against the rest of the correlation) is the confidence.
+
+Linear drift (e.g. PAL-sourced dubs running ~4% fast) smears the correlation
+peak, so a hierarchical tempo scan time-stretches the dub envelope over a grid
+of speed factors (couple of percent around 1.0, refined in stages down to
+1e-5) and keeps the factor whose correlation peak is sharpest -- the correct
+tempo un-smears the peak dramatically, and a wrong one never beats the
+identity baseline by the required margin. A detected factor can be corrected
+with :func:`resample_dub` via ``atempo`` -- which re-encodes the dub audio, so
+the pipeline only takes that path when the user opts in.
+
+Only :mod:`numpy` is needed (FFT correlation), no scipy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import ffmpeg
+import numpy as np
+
+from ....config import logger
+from ...common.common import _run_ffmpeg_with_progress
+
+# Decode/analysis parameters. 8 kHz mono is plenty for an energy envelope; the
+# envelope itself is sampled at 100 Hz (10 ms resolution, refined below by
+# parabolic peak interpolation).
+_DECODE_RATE = 8000
+_ENVELOPE_RATE = 100
+
+#: Largest constant offset (seconds) the global search considers.
+DEFAULT_MAX_OFFSET = 600.0
+
+#: Peak z-score below which a detected offset should not be trusted. A true
+#: match gives a needle-sharp peak (z >> 10); uncorrelated tracks stay ~3-5.
+DEFAULT_MIN_CONFIDENCE = 8.0
+
+#: Offset change across the whole episode (seconds) beyond which drift is
+#: reported (and correctable via resample).
+DRIFT_THRESHOLD = 0.2
+
+# Tempo scan: stretch factors 1.0 +/- _TEMPO_SPAN are searched at the first
+# step size, then the best factor is refined at each finer step. The final
+# step bounds the tempo error at 1e-5 (~14 ms residual drift over 24 min).
+_TEMPO_SPAN = 0.06  # covers PAL <-> film (~4.3%) with headroom
+_TEMPO_STEPS = (2e-3, 2e-4, 2e-5)
+
+# Shortest dub (seconds) for which drift analysis is attempted at all.
+_DRIFT_MIN_DURATION = 300.0
+
+# A non-identity tempo must beat the identity peak by this much z-score (and
+# clear DEFAULT_MIN_CONFIDENCE) before drift is claimed -- otherwise noise
+# could pick a wrong speed. A genuinely drifted dub un-smears dramatically.
+_TEMPO_MARGIN = 5.0
+
+# Seconds around the peak excluded when estimating the correlation noise floor.
+_PEAK_EXCLUDE = 1.0
+
+# Japanese language tags used to pick the preferred reference audio stream.
+_JP_TAGS = {"jpn", "ja", "jp", "japanese"}
+
+
+@dataclass
+class AlignResult:
+    """Outcome of aligning one dub against one reference track.
+
+    ``offset`` is the best *constant* delay (seconds, may be negative) to apply
+    to the dub via ``-itsoffset``; ``confidence`` is the correlation peak
+    z-score. When drift was detected, ``drift`` is how much the offset changes
+    across the whole episode, ``tempo_ratio`` the ``atempo`` factor that
+    corrects it, and ``post_tempo_offset`` the residual constant offset to use
+    *after* the dub has been retimed with that factor.
+    """
+
+    offset: float
+    confidence: float
+    drift: float = 0.0
+    drift_confidence: float = 0.0
+    tempo_ratio: float = 1.0
+    post_tempo_offset: float = 0.0
+
+    @property
+    def has_drift(self) -> bool:
+        return abs(self.drift) > DRIFT_THRESHOLD
+
+
+def _pick_reference_stream(path: Path) -> int:
+    """Audio-stream index (``0:a:N``) to correlate against: JP if tagged, else
+    the first audio stream. Raises if the file has no audio at all."""
+
+    try:
+        probe = ffmpeg.probe(str(path))
+    except ffmpeg.Error as exc:
+        raise RuntimeError(f"Could not probe reference audio: {path}") from exc
+
+    audio_streams = [
+        s for s in probe.get("streams", []) if s.get("codec_type") == "audio"
+    ]
+    if not audio_streams:
+        raise RuntimeError(f"No audio stream in reference file: {path}")
+
+    for idx, stream in enumerate(audio_streams):
+        lang = (stream.get("tags", {}).get("language") or "").lower()
+        if lang in _JP_TAGS:
+            return idx
+    return 0
+
+
+def _decode_mono(path: Path, stream_index: int = 0) -> np.ndarray:
+    """Decode one audio stream of *path* to mono float32 at ``_DECODE_RATE``."""
+
+    try:
+        out, _ = (
+            ffmpeg.input(str(path))
+            .output(
+                "pipe:",
+                format="s16le",
+                acodec="pcm_s16le",
+                ac=1,
+                ar=_DECODE_RATE,
+                map=f"0:a:{stream_index}",
+            )
+            .run(capture_stdout=True, capture_stderr=True)
+        )
+    except ffmpeg.Error as exc:
+        tail = (exc.stderr or b"").decode(errors="replace").strip().splitlines()
+        raise RuntimeError(
+            f"ffmpeg failed decoding {Path(path).name}: "
+            + (tail[-1] if tail else "unknown error")
+        ) from exc
+
+    return np.frombuffer(out, np.int16).astype(np.float32) / 32768.0
+
+
+def _onset_envelope(samples: np.ndarray) -> np.ndarray:
+    """Half-wave-rectified log-energy onset envelope at ``_ENVELOPE_RATE`` Hz,
+    z-normalised. Loud transient events (music hits, SFX) dominate it, which is
+    exactly the language-independent signal shared between dub and original."""
+
+    hop = _DECODE_RATE // _ENVELOPE_RATE
+    n_frames = len(samples) // hop
+    if n_frames == 0:
+        return np.zeros(0, dtype=np.float32)
+
+    frames = samples[: n_frames * hop].reshape(n_frames, hop)
+    rms = np.sqrt((frames.astype(np.float64) ** 2).mean(axis=1))
+    env = np.log1p(rms * 100.0)
+
+    onset = np.diff(env, prepend=env[:1])
+    np.maximum(onset, 0.0, out=onset)
+
+    std = onset.std()
+    if std < 1e-8:
+        return np.zeros_like(onset)
+    return (onset - onset.mean()) / std
+
+
+def _xcorr_peak_fft(
+    ref_fft: np.ndarray,
+    n: int,
+    qry_env: np.ndarray,
+    min_lag: int,
+    max_lag: int,
+) -> tuple[float, float]:
+    """Correlation-peak search against a precomputed reference spectrum, so a
+    tempo scan pays for the reference FFT only once."""
+
+    if len(qry_env) == 0:
+        return 0.0, 0.0
+
+    corr = np.fft.irfft(ref_fft * np.conj(np.fft.rfft(qry_env, n)), n)
+
+    # corr[k] = sum(ref[m + k] * qry[m]); negative lags wrap to the array end.
+    lags = np.arange(n)
+    lags[lags > n // 2] -= n
+
+    valid = (lags >= min_lag) & (lags <= max_lag)
+    if not valid.any():
+        return 0.0, 0.0
+
+    valid_idx = np.flatnonzero(valid)
+    seg = corr[valid_idx]
+    best = int(valid_idx[np.argmax(seg)])
+    peak_lag = int(lags[best])
+    peak_val = corr[best]
+
+    # Confidence: peak z-score against the searched range, excluding the
+    # immediate neighbourhood of the peak itself.
+    exclude = int(_PEAK_EXCLUDE * _ENVELOPE_RATE)
+    noise = seg[np.abs(lags[valid_idx] - peak_lag) > exclude]
+    if len(noise) < 8:
+        return float(peak_lag), 0.0
+    noise_std = noise.std()
+    confidence = (
+        float((peak_val - noise.mean()) / noise_std) if noise_std > 1e-12 else 0.0
+    )
+
+    # Parabolic interpolation for sub-envelope-sample lag precision.
+    refined = float(peak_lag)
+    prev_i, next_i = (best - 1) % n, (best + 1) % n
+    y0, y1, y2 = corr[prev_i], peak_val, corr[next_i]
+    denom = y0 - 2.0 * y1 + y2
+    if abs(denom) > 1e-12:
+        delta = 0.5 * (y0 - y2) / denom
+        if abs(delta) <= 1.0:
+            refined += float(delta)
+
+    return refined, confidence
+
+
+def _xcorr_peak(
+    ref_env: np.ndarray,
+    qry_env: np.ndarray,
+    min_lag: int,
+    max_lag: int,
+) -> tuple[float, float]:
+    """FFT cross-correlation peak of *qry_env* against *ref_env*.
+
+    Returns ``(lag, confidence)`` where ``lag`` (envelope samples, may be
+    fractional after parabolic refinement) is how far *qry* must be delayed to
+    line up with *ref*, and ``confidence`` is the peak's z-score against the
+    rest of the searched correlation range.
+    """
+
+    if len(ref_env) == 0 or len(qry_env) == 0:
+        return 0.0, 0.0
+
+    n = 1 << int(len(ref_env) + len(qry_env) - 1).bit_length()
+    return _xcorr_peak_fft(np.fft.rfft(ref_env, n), n, qry_env, min_lag, max_lag)
+
+
+def _stretch(env: np.ndarray, factor: float) -> np.ndarray:
+    """Time-stretch an envelope by *factor* (linear interpolation). A dub that
+    plays ``factor`` times too fast lines up with the reference after its
+    envelope is stretched by ``factor``."""
+
+    if factor == 1.0 or len(env) == 0:
+        return env
+    idx = np.arange(int(len(env) * factor)) / factor
+    return np.interp(idx, np.arange(len(env)), env).astype(env.dtype)
+
+
+def _tempo_scan(
+    ref_env: np.ndarray,
+    dub_env: np.ndarray,
+    max_lag: int,
+) -> tuple[float, float, float]:
+    """Find the tempo factor whose stretched-dub correlation peak is sharpest.
+
+    Coarse-to-fine grid search: the full ``1 +/- _TEMPO_SPAN`` range at the
+    first step size, then successively finer grids around the running best.
+    Returns ``(factor, lag, confidence)``.
+    """
+
+    n = 1 << int(len(ref_env) + len(dub_env) * (1 + _TEMPO_SPAN)).bit_length()
+    ref_fft = np.fft.rfft(ref_env, n)
+
+    best_factor, best_lag, best_conf = 1.0, 0.0, -np.inf
+    span = _TEMPO_SPAN
+    center = 1.0
+    for step in _TEMPO_STEPS:
+        for factor in np.arange(center - span, center + span + step / 2, step):
+            lag, conf = _xcorr_peak_fft(
+                ref_fft, n, _stretch(dub_env, float(factor)), -max_lag, max_lag
+            )
+            if conf > best_conf:
+                best_factor, best_lag, best_conf = float(factor), lag, conf
+        center = best_factor
+        span = step  # next pass zooms into the winning grid cell
+    return best_factor, best_lag, best_conf
+
+
+def detect_offset(
+    dub_path,
+    ref_path,
+    max_offset: float = DEFAULT_MAX_OFFSET,
+    check_drift: bool = True,
+) -> AlignResult:
+    """Detect the offset between *dub_path* and *ref_path*'s audio.
+
+    *ref_path* may be a full video container; its JP audio stream is preferred
+    as the reference (falling back to the first audio stream). The returned
+    :class:`AlignResult` always carries the best constant offset; drift fields
+    are populated when the tracks are long enough for the two-window check.
+    """
+
+    dub_path = Path(dub_path)
+    ref_path = Path(ref_path)
+
+    ref_stream = _pick_reference_stream(ref_path)
+    ref_env = _onset_envelope(_decode_mono(ref_path, ref_stream))
+    dub_env = _onset_envelope(_decode_mono(dub_path))
+
+    rate = _ENVELOPE_RATE
+    max_lag = int(max_offset * rate)
+    lag, confidence = _xcorr_peak(ref_env, dub_env, -max_lag, max_lag)
+    offset = lag / rate
+
+    result = AlignResult(
+        offset=offset, confidence=confidence, post_tempo_offset=offset
+    )
+    logger.debug(
+        f"[DUBSYNC] global offset {offset:+.3f}s (confidence z={confidence:.1f}) "
+        f"for {dub_path.name}"
+    )
+
+    dub_duration = len(dub_env) / rate
+    if not check_drift or dub_duration < _DRIFT_MIN_DURATION:
+        return result
+
+    # Linear drift smears the identity-tempo peak; scanning stretch factors
+    # un-smears it at the true speed ratio. A non-identity factor must beat
+    # the identity peak by a clear margin so noise can't pick a wrong speed.
+    factor, t_lag, t_conf = _tempo_scan(ref_env, dub_env, max_lag)
+    logger.debug(
+        f"[DUBSYNC] tempo scan: x{factor:.6f} z={t_conf:.1f} "
+        f"(identity z={confidence:.1f})"
+    )
+    if (
+        factor == 1.0
+        or t_conf < DEFAULT_MIN_CONFIDENCE
+        or t_conf < confidence + _TEMPO_MARGIN
+    ):
+        return result
+
+    result.confidence = t_conf
+    result.drift = (factor - 1.0) * dub_duration
+    result.drift_confidence = t_conf
+    if result.has_drift:
+        # Slowing the dub by the detected factor (atempo = 1/factor) removes
+        # the drift; the scan's peak lag is the remaining constant offset.
+        result.tempo_ratio = 1.0 / factor
+        result.post_tempo_offset = t_lag / rate
+
+    return result
+
+
+def resample_dub(
+    dub_path, dest_path, tempo_ratio: float, label: str = "", acodec: str = "flac"
+) -> Path:
+    """Retime *dub_path* by *tempo_ratio* (``atempo``) to correct linear drift.
+
+    This is the one lossy step in DubSync: ``atempo`` requires decoding, so the
+    result is re-encoded. FLAC by default, so no further generational loss
+    after the decode; callers retiming an already-lossy stream rip (where a
+    lossless track would balloon the file) can ask for a lossy *acodec*
+    instead. Only called when the user opted in to resampling.
+    """
+
+    dub_path = Path(dub_path)
+    dest_path = Path(dest_path)
+
+    logger.debug(
+        f"[DUBSYNC] retiming dub with atempo={tempo_ratio:.6f} -> {dest_path.name}"
+    )
+
+    encode_kwargs = {"acodec": acodec}
+    if acodec == "aac":
+        encode_kwargs["audio_bitrate"] = "192k"
+
+    node = ffmpeg.input(str(dub_path)).output(
+        str(dest_path),
+        af=f"atempo={tempo_ratio:.8f}",
+        map="0:a:0",
+        **encode_kwargs,
+    )
+    _run_ffmpeg_with_progress(node, label=label)
+    return dest_path

--- a/src/aniworld/models/aniworld_to/dubsync/extract.py
+++ b/src/aniworld/models/aniworld_to/dubsync/extract.py
@@ -1,0 +1,76 @@
+"""Lossless extraction of a dub audio track from an AniWorld/SerienStream episode.
+
+Given an episode model object, resolve its stream (with provider fallback) for
+the requested language and copy just the audio into a standalone file with
+``-c:a copy`` -- no re-encode, so the dub stays bit-exact. The result is later
+grafted into the archive-quality target video by :mod:`remux`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ffmpeg
+
+from ....config import PROVIDER_HEADERS_D, logger
+from ...common.common import (
+    _resolve_stream_url_with_fallback,
+    _run_ffmpeg_with_progress,
+)
+
+
+def _build_input_kwargs(stream_url: str, provider_name: str) -> dict:
+    """Mirror ``download()``'s ffmpeg input options: reconnect handling, HLS
+    segment-extension allowance, and provider request headers."""
+
+    input_kwargs = {
+        "reconnect": 1,
+        "reconnect_streamed": 1,
+        "reconnect_delay_max": 30,
+    }
+    if ".m3u8" in (stream_url or "").split("?", 1)[0].lower():
+        input_kwargs["allowed_extensions"] = "ALL"
+
+    headers = PROVIDER_HEADERS_D.get(provider_name, {})
+    if headers:
+        header_list = [f"{k}: {v}" for k, v in headers.items()]
+        input_kwargs["headers"] = "\r\n".join(header_list) + "\r\n"
+
+    return input_kwargs
+
+
+def extract_dub_audio(
+    episode,
+    dest_path,
+    audio_language: str = "German Dub",
+    label: str = "",
+):
+    """Extract *episode*'s ``audio_language`` audio track to ``dest_path``.
+
+    Sets the episode's selected language, resolves the stream URL via provider
+    fallback, then copies the first audio stream losslessly. Returns
+    ``(dest_path, provider_name)``. Raises on resolution/ffmpeg failure so the
+    caller can report the episode as failed.
+    """
+
+    dest_path = Path(dest_path)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    episode.selected_language = audio_language
+
+    stream_url, provider_name = _resolve_stream_url_with_fallback(episode, "DubSync")
+    input_kwargs = _build_input_kwargs(stream_url, provider_name)
+
+    logger.debug(
+        f"[DUBSYNC] extracting '{audio_language}' audio via {provider_name} "
+        f"-> {dest_path.name}"
+    )
+
+    node = ffmpeg.input(stream_url, **input_kwargs).output(
+        str(dest_path),
+        map="0:a:0?",
+        acodec="copy",
+    )
+    _run_ffmpeg_with_progress(node, label=label)
+
+    return dest_path, provider_name

--- a/src/aniworld/models/aniworld_to/dubsync/matcher.py
+++ b/src/aniworld/models/aniworld_to/dubsync/matcher.py
@@ -1,0 +1,406 @@
+"""DubSync file matcher.
+
+Pairs local high-quality video files (e.g. Blu-ray/Nyaa rips) with the
+corresponding AniWorld episodes so a German dub track can later be grafted in.
+
+Two responsibilities, kept independent so the parsing half is unit-testable
+without any network access:
+
+1. Parse a directory of video filenames into ``(season, episode)`` keys,
+   handling common scene/BD naming (``S01E01``, ``Show - 01``, ``01v2``,
+   ``1x01``, ``- 12 (1080p)``, absolute numbering).
+2. Enumerate the AniWorld source (series / season / episode URL or object) and
+   pair each parsed file with its matching :class:`AniworldEpisode`, reporting
+   whatever could not be paired in either direction.
+
+Only :func:`match_directory` touches the network (it fetches the source
+episode list). Everything under "Filename parsing" is pure stdlib.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator, List, Optional, Tuple
+
+# Extensions we treat as remuxable video containers.
+VIDEO_EXTENSIONS = {
+    ".mkv",
+    ".mp4",
+    ".m4v",
+    ".avi",
+    ".mov",
+    ".ts",
+    ".m2ts",
+    ".webm",
+    ".wmv",
+    ".flv",
+    ".mpg",
+    ".mpeg",
+    ".ogm",
+}
+
+# Release noise that contains digits and would otherwise be mistaken for an
+# episode number. Stripped (case-insensitively) before the episode-only search.
+_NOISE_PATTERNS = [
+    r"\d{3,4}x\d{3,4}",            # resolution: 1920x1080
+    r"\b\d{3,4}[pi]\b",           # 1080p, 720p, 1080i
+    r"\b(?:x|h)\.?26[45]\b",      # x264 / x265 / h264 / h265
+    r"\bhevc\b",
+    r"\bavc\b",
+    r"\b(?:8|10|12)\s?bit\b",
+    r"\b(?:aac|ac3|eac3|dts|flac|opus|mp3|truehd)\b",
+    r"\b(?:blu-?ray|bd(?:rip)?|web-?dl|web-?rip|hdtv|dvd-?rip|remux)\b",
+    r"\b(?:dual|multi)(?:-?audio)?\b",
+    r"\b(?:19|20)\d{2}\b",        # years
+    r"\b[0-9a-f]{8}\b",           # crc32 tag
+]
+_NOISE_RE = re.compile("|".join(_NOISE_PATTERNS), re.IGNORECASE)
+
+_BRACKET_RE = re.compile(r"\[[^\]]*\]|\([^)]*\)|\{[^}]*\}")
+
+# Explicit season+episode, e.g. S01E02, s1.e2, 1x02.
+_SxxExx_RE = re.compile(r"(?i)s(\d{1,2})[\s._-]*e(\d{1,4})")
+_NxNN_RE = re.compile(r"(?i)\b(\d{1,2})x(\d{1,3})\b")
+
+# Season detected in a folder / filename ("S04", "Staffel 4", "Season 4",
+# "Re_Zero_S4"). Underscores are word chars, so use an explicit non-alnum
+# lookbehind instead of \b to catch "_S4".
+_SEASON_RE = re.compile(
+    r"(?i)(?<![a-z0-9])(?:s|staffel|season)[\s._-]*(\d{1,2})(?![0-9])"
+)
+
+# Episode-only markers, tried in order of confidence.
+_EPISODE_PATTERNS = [
+    re.compile(r"(?i)\b(?:e|ep|episode|folge)[\s._-]*(\d{1,4})"),
+    re.compile(r"(?:^|[\s._-])-[\s._-]*(\d{1,4})(?:v\d+)?(?=[\s._-]|$)"),  # " - 01", "-01v2"
+    re.compile(r"(?:^|[\s._-])#?(\d{1,4})(?:v\d+)?(?=[\s._-]|$)"),          # standalone
+]
+
+
+# ---------------------------------------------------------------------------
+# Result containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ParsedFile:
+    """A local video file whose ``(season, episode)`` could be parsed."""
+
+    path: Path
+    season: Optional[int]  # None when the filename carried no season hint
+    episode: int
+
+
+@dataclass
+class MatchReport:
+    """Outcome of pairing a directory against an AniWorld source."""
+
+    # (local file, matching AniWorld episode)
+    pairs: List[Tuple[ParsedFile, "object"]] = field(default_factory=list)
+    # files whose season/episode could not be parsed at all
+    unmatched_files: List[Path] = field(default_factory=list)
+    # files that parsed but had no corresponding source episode
+    unpaired_files: List[ParsedFile] = field(default_factory=list)
+    # source episodes (season, number) with no local file
+    missing_sources: List[Tuple[Optional[int], int]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Filename parsing (pure, no network)
+# ---------------------------------------------------------------------------
+
+
+def _strip_noise(stem: str) -> str:
+    """Remove bracketed groups and release metadata so only the title/number
+    survives for the episode-only heuristics."""
+
+    text = _BRACKET_RE.sub(" ", stem)
+    text = _NOISE_RE.sub(" ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _find_episode_number(text: str) -> Optional[int]:
+    for pattern in _EPISODE_PATTERNS:
+        matches = list(pattern.finditer(text))
+        if matches:
+            # Prefer the last hit: the episode number sits near the end,
+            # after the show title.
+            return int(matches[-1].group(1))
+    return None
+
+
+def parse_filename(name: str) -> Optional[Tuple[Optional[int], int]]:
+    """Parse a filename into ``(season, episode)``.
+
+    ``season`` is ``None`` when the name carried no season marker (common with
+    single-season anime named ``Show - 01``); the caller resolves it from the
+    folder or the source. Returns ``None`` when no episode number is found.
+    """
+
+    stem = os.path.splitext(name)[0]
+
+    m = _SxxExx_RE.search(stem)
+    if m:
+        return int(m.group(1)), int(m.group(2))
+
+    cleaned = _strip_noise(stem)
+
+    m = _NxNN_RE.search(cleaned)
+    if m:
+        return int(m.group(1)), int(m.group(2))
+
+    episode = _find_episode_number(cleaned)
+    if episode is not None:
+        return None, episode
+
+    return None
+
+
+def parse_season_from_text(text: str) -> Optional[int]:
+    """Extract a season number from a folder or file name, if present."""
+
+    m = _SEASON_RE.search(text)
+    return int(m.group(1)) if m else None
+
+
+def _iter_video_files(target: Path, recursive: bool) -> Iterator[Path]:
+    walker = target.rglob("*") if recursive else target.iterdir()
+    for path in sorted(walker):
+        if path.is_file() and path.suffix.lower() in VIDEO_EXTENSIONS:
+            yield path
+
+
+def scan_directory(
+    target_dir: os.PathLike | str, recursive: bool = False
+) -> Tuple[List[ParsedFile], List[Path]]:
+    """Scan ``target_dir`` for video files and parse each into a season/episode.
+
+    Returns ``(parsed, unmatched)`` where *unmatched* holds files whose
+    episode number could not be determined. Season is inferred from the folder
+    name when the filename itself lacks one; it may still be ``None`` here and
+    is finalised during pairing.
+    """
+
+    target = Path(target_dir)
+    if not target.is_dir():
+        raise NotADirectoryError(f"Not a directory: {target}")
+
+    folder_season = parse_season_from_text(target.name)
+
+    parsed: List[ParsedFile] = []
+    unmatched: List[Path] = []
+
+    for path in _iter_video_files(target, recursive):
+        result = parse_filename(path.name)
+        if result is None:
+            unmatched.append(path)
+            continue
+        season, episode = result
+        if season is None:
+            season = folder_season
+        parsed.append(ParsedFile(path=path, season=season, episode=episode))
+
+    return parsed, unmatched
+
+
+# ---------------------------------------------------------------------------
+# Source enumeration + pairing (touches the network)
+# ---------------------------------------------------------------------------
+
+
+def _build_source_from_url(source_url: str):
+    """Resolve a URL string to a series / season / episode model object."""
+
+    from ....providers import normalize_url, resolve_provider
+
+    url = normalize_url(source_url)
+    provider = resolve_provider(url)
+
+    if provider.season_pattern and provider.season_pattern.fullmatch(url):
+        return provider.season_cls(url)
+    if provider.series_pattern and provider.series_pattern.fullmatch(url):
+        return provider.series_cls(url)
+    if provider.episode_pattern and provider.episode_pattern.fullmatch(url):
+        return provider.episode_cls(url)
+
+    raise ValueError(f"Unsupported DubSync source URL: {source_url}")
+
+
+def _iter_source_episodes(source) -> Iterator[Tuple[Optional[int], object]]:
+    """Yield ``(season_number, episode)`` for every episode in *source*.
+
+    *source* may be a URL string, a series object (has ``.seasons``), a season
+    object (has ``.episodes``), or a single episode object.
+    """
+
+    if isinstance(source, str):
+        source = _build_source_from_url(source)
+
+    if hasattr(source, "seasons"):  # series
+        for season in source.seasons:
+            for episode in season.episodes:
+                yield season.season_number, episode
+    elif hasattr(source, "episodes"):  # season
+        season_number = getattr(source, "season_number", None)
+        for episode in source.episodes:
+            yield season_number, episode
+    else:  # single episode
+        season_number = None
+        try:
+            season_number = source.season.season_number
+        except Exception:  # noqa: BLE001 - season lookup is best-effort
+            pass
+        yield season_number, source
+
+
+def build_source_index(source):
+    """Index a source into lookup maps used for pairing.
+
+    Returns ``(by_key, by_abs, season_numbers)``:
+      * ``by_key``  -- ``{(season, episode): episode_obj}``
+      * ``by_abs``  -- ``{episode_number: (season, episode_obj)}`` for numbers
+        that are unique across all seasons (enables absolute-numbering fallback)
+      * ``season_numbers`` -- the set of distinct season numbers seen
+    """
+
+    by_key: dict = {}
+    abs_seen: dict = {}
+    abs_dupes: set = set()
+    season_numbers: set = set()
+    numberless: list = []
+
+    for season_number, episode in _iter_source_episodes(source):
+        number = getattr(episode, "episode_number", None)
+        if number is None:
+            numberless.append((season_number, episode))
+            continue
+        season_numbers.add(season_number)
+        by_key[(season_number, number)] = episode
+        if number in abs_seen:
+            abs_dupes.add(number)
+        else:
+            abs_seen[number] = (season_number, episode)
+
+    # Movie-site sources (MegaKino/FilmPalast) resolve to a single episode
+    # object without an episode_number; treat a lone numberless episode as
+    # episode 1 so it stays addressable via (None, 1).
+    if not by_key and len(numberless) == 1:
+        season_number, episode = numberless[0]
+        by_key[(season_number, 1)] = episode
+        season_numbers.add(season_number)
+        abs_seen[1] = (season_number, episode)
+
+    by_abs = {n: v for n, v in abs_seen.items() if n not in abs_dupes}
+    return by_key, by_abs, season_numbers
+
+
+def match_directory(
+    target_dir: os.PathLike | str,
+    source,
+    recursive: bool = False,
+    selected: Optional[Iterable[Tuple[Optional[int], int]]] = None,
+    explicit: Optional[Iterable[Tuple[Optional[int], int, str]]] = None,
+) -> MatchReport:
+    """Pair the video files in ``target_dir`` with *source*'s episodes.
+
+    *source* is anything :func:`_iter_source_episodes` accepts (a URL string or
+    a series/season/episode object). Season is resolved as: the filename's own
+    season if present, else the source's single season number when the source
+    has exactly one, else ``1``. Unmatched local files fall back to absolute
+    numbering when the source has globally-unique episode numbers.
+
+    ``selected`` optionally restricts pairing to the given
+    ``(season, episode)`` keys (e.g. the user's checklist in the web UI);
+    everything else in the source is treated as if it did not exist.
+
+    ``explicit`` provides user-confirmed ``(season, episode, filename)``
+    triples -- used for movies, whose filenames carry no season/episode
+    pattern. The filename may be a bare name, a path relative to
+    ``target_dir``, or absolute. Explicit pairs bypass filename parsing and
+    the ``selected`` filter; a triple whose source episode or local file
+    cannot be found lands in ``missing_sources``.
+    """
+
+    parsed, unmatched = scan_directory(target_dir, recursive=recursive)
+    by_key, by_abs, season_numbers = build_source_index(source)
+
+    explicit_pairs: List[Tuple[ParsedFile, object]] = []
+    explicit_missing: List[Tuple[Optional[int], int]] = []
+    if explicit:
+        target = Path(target_dir)
+        all_paths = [pf.path for pf in parsed] + list(unmatched)
+
+        def _find_file(name: str) -> Optional[Path]:
+            for p in all_paths:
+                try:
+                    rel = str(p.relative_to(target))
+                except ValueError:
+                    rel = p.name
+                if name in (p.name, rel, str(p)):
+                    return p
+            return None
+
+        used_paths: set = set()
+        for s, e, fname in explicit:
+            key = (int(s) if s is not None else None, int(e))
+            matched_key = key
+            episode = by_key.get(key)
+            # Movie-site sources index their single film as (None, 1) while
+            # the web UI labels it season 1; fall back on episode number.
+            if episode is None and (None, key[1]) in by_key:
+                matched_key = (None, key[1])
+                episode = by_key[matched_key]
+            path = _find_file(fname)
+            if episode is None or path is None or path in used_paths:
+                explicit_missing.append(key)
+                continue
+            used_paths.add(path)
+            explicit_pairs.append(
+                (ParsedFile(path=path, season=key[0], episode=key[1]), episode)
+            )
+            by_key.pop(matched_key, None)
+            by_abs = {n: v for n, v in by_abs.items() if v[1] is not episode}
+
+        parsed = [pf for pf in parsed if pf.path not in used_paths]
+        unmatched = [p for p in unmatched if p not in used_paths]
+        season_numbers = {k[0] for k in by_key}
+
+    if selected is not None:
+        sel = {(s, int(e)) for s, e in selected}
+        by_key = {k: v for k, v in by_key.items() if k in sel}
+        by_abs = {n: v for n, v in by_abs.items() if (v[0], n) in sel}
+        season_numbers = {k[0] for k in by_key}
+
+    single_season = next(iter(season_numbers)) if len(season_numbers) == 1 else None
+
+    report = MatchReport(unmatched_files=list(unmatched))
+    report.pairs.extend(explicit_pairs)
+    used_keys: set = set()
+
+    for pf in parsed:
+        season = pf.season
+        if season is None:
+            season = single_season if single_season is not None else 1
+
+        episode = by_key.get((season, pf.episode))
+        matched_key = (season, pf.episode)
+
+        # Absolute-numbering fallback: only when the file gave no explicit
+        # season and the source numbers are globally unique.
+        if episode is None and pf.season is None and pf.episode in by_abs:
+            matched_key, episode = by_abs[pf.episode]
+
+        if episode is None:
+            report.unpaired_files.append(pf)
+            continue
+
+        report.pairs.append((pf, episode))
+        used_keys.add(matched_key)
+
+    report.missing_sources = [
+        key for key in by_key if key not in used_keys
+    ] + explicit_missing
+    return report

--- a/src/aniworld/models/aniworld_to/dubsync/pipeline.py
+++ b/src/aniworld/models/aniworld_to/dubsync/pipeline.py
@@ -1,0 +1,345 @@
+"""DubSync pipeline: match -> preflight -> extract -> align -> remux -> cleanup.
+
+Orchestrates grafting a German dub (from an AniWorld/SerienStream source) onto a
+folder of archive-quality video files. The dub's offset against each target is
+detected automatically per episode (:mod:`align`); a manual ``offset`` overrides
+detection, and low-confidence detections fall back to 0 and are flagged so the
+user can verify them.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+from ....config import LANG_CODE_MAP, LANG_KEY_MAP, LANG_LABELS, logger
+from ...common.common import check_downloaded
+from .align import DEFAULT_MIN_CONFIDENCE, detect_offset, resample_dub
+from .extract import extract_dub_audio
+from .matcher import MatchReport, match_directory
+from .remux import remux_with_dub
+
+
+def dubsync_env_defaults() -> dict:
+    """DubSync defaults from ``ANIWORLD_DUBSYNC_*`` (see .env.example).
+
+    The CLI exports its flags to these variables before calling, so both the
+    CLI and the web queue worker resolve settings through this one helper.
+    """
+
+    offset_raw = os.getenv("ANIWORLD_DUBSYNC_OFFSET", "").strip()
+    try:
+        offset = float(offset_raw) if offset_raw else None
+    except ValueError:
+        logger.warning(f"[DUBSYNC] ignoring invalid ANIWORLD_DUBSYNC_OFFSET: {offset_raw!r}")
+        offset = None
+
+    return {
+        "target_dir": os.getenv("ANIWORLD_DUBSYNC_TARGET_DIR", "").strip(),
+        "offset": offset,
+        "auto_align": os.getenv("ANIWORLD_DUBSYNC_AUTO_ALIGN", "1") != "0",
+        "allow_resample": os.getenv("ANIWORLD_DUBSYNC_ALLOW_RESAMPLE", "0") == "1",
+        "cleanup": os.getenv("ANIWORLD_DUBSYNC_CLEANUP", "0") == "1",
+        "audio_language": os.getenv("ANIWORLD_DUBSYNC_AUDIO_LANG", "German Dub").strip()
+        or "German Dub",
+    }
+
+
+@dataclass
+class FileOutcome:
+    """What happened to one target file during a run."""
+
+    path: Path
+    status: str  # "done" | "skipped" | "failed"
+    detail: str = ""
+
+
+def _resolve_audio_code(audio_language: str) -> str:
+    """Map a language label ("German Dub") to its ISO code ("deu")."""
+
+    key = next((k for k, v in LANG_LABELS.items() if v == audio_language), None)
+    if key is None:
+        return "deu"
+    audio_enum, _ = LANG_KEY_MAP[key]
+    return LANG_CODE_MAP.get(audio_enum) or "deu"
+
+
+def _print_report(report: MatchReport, target_dir) -> None:
+    """Human-readable match table (also the whole output of ``--dry-run``)."""
+
+    print(f"\nDubSync match report for: {target_dir}")
+    print(f"  matched:   {len(report.pairs)}")
+    print(f"  unmatched: {len(report.unmatched_files)} (no episode number parsed)")
+    print(f"  unpaired:  {len(report.unpaired_files)} (parsed, no source episode)")
+    print(f"  missing:   {len(report.missing_sources)} (source episode, no local file)")
+
+    if report.pairs:
+        print("\n  Pairs:")
+        for pf, episode in report.pairs:
+            season = pf.season if pf.season is not None else "?"
+            title = getattr(episode, "title_de", None) or getattr(
+                episode, "title_en", ""
+            )
+            print(
+                f"    S{season}E{pf.episode:02d}  {pf.path.name}"
+                + (f"  <-  {title}" if title else "")
+            )
+
+    if report.unpaired_files:
+        print("\n  Unpaired (parsed but no matching source episode):")
+        for pf in report.unpaired_files:
+            season = pf.season if pf.season is not None else "?"
+            print(f"    S{season}E{pf.episode:02d}  {pf.path.name}")
+
+    if report.unmatched_files:
+        print("\n  Unmatched (could not parse an episode number):")
+        for path in report.unmatched_files:
+            print(f"    {path.name}")
+
+    if report.missing_sources:
+        print("\n  Missing (source episodes with no local file):")
+        for season, number in report.missing_sources:
+            season_str = season if season is not None else "?"
+            print(f"    S{season_str}E{number:02d}")
+    print()
+
+
+def _align_dub(
+    dub_tmp: Path,
+    target: Path,
+    allow_resample: bool,
+    min_confidence: float,
+) -> Tuple[float, Path, str]:
+    """Detect the dub's offset against *target* and handle drift.
+
+    Returns ``(offset, dub_path, note)`` -- *dub_path* differs from *dub_tmp*
+    only when drift correction re-timed the dub into a new temp file. *note*
+    describes what alignment decided (kept in the outcome detail so
+    low-confidence fallbacks are visible in the final report).
+    """
+
+    result = detect_offset(dub_tmp, target)
+
+    if result.confidence < min_confidence:
+        note = (
+            f"low-confidence alignment (z={result.confidence:.1f} < "
+            f"{min_confidence:.0f}); fell back to offset 0.00s - verify manually"
+        )
+        logger.warning(f"[DUBSYNC] {target.name}: {note}")
+        return 0.0, dub_tmp, note
+
+    if result.has_drift:
+        if allow_resample and result.drift_confidence >= min_confidence:
+            retimed = dub_tmp.with_name(f"{dub_tmp.stem}.retimed.mka")
+            resample_dub(
+                dub_tmp, retimed, result.tempo_ratio, label=target.stem
+            )
+            note = (
+                f"offset {result.post_tempo_offset:+.2f}s; drift "
+                f"{result.drift:+.2f}s corrected via atempo="
+                f"{result.tempo_ratio:.5f} (dub re-encoded)"
+            )
+            return result.post_tempo_offset, retimed, note
+        note = (
+            f"offset {result.offset:+.2f}s (z={result.confidence:.1f}); drift "
+            f"{result.drift:+.2f}s detected but resample "
+            + ("low-confidence" if allow_resample else "disabled")
+            + " - sync may wander over the episode"
+        )
+        logger.warning(f"[DUBSYNC] {target.name}: {note}")
+        return result.offset, dub_tmp, note
+
+    note = f"offset {result.offset:+.2f}s (z={result.confidence:.1f})"
+    return result.offset, dub_tmp, note
+
+
+def _dry_run_align(
+    pairs,
+    tmp_dir: Path,
+    audio_language: str,
+    audio_code: str,
+    allow_resample: bool,
+    min_confidence: float,
+) -> None:
+    """Extract each dub to temp and print its detected offset (no writes to
+    any target file). This is the trust-building step before a real run."""
+
+    print("  Detected offsets (dry-run, nothing written):")
+    for pf, episode in pairs:
+        target = pf.path
+        dub_tmp = tmp_dir / f"{target.stem}.{audio_code}.mka"
+        try:
+            extract_dub_audio(
+                episode, dub_tmp, audio_language=audio_language, label=target.stem
+            )
+            result = detect_offset(dub_tmp, target)
+            line = f"offset {result.offset:+.3f}s  (z={result.confidence:.1f})"
+            if result.confidence < min_confidence:
+                line += "  LOW CONFIDENCE - would fall back to 0"
+            elif result.has_drift:
+                line += (
+                    f"  drift {result.drift:+.2f}s"
+                    + (
+                        f" -> atempo={result.tempo_ratio:.5f}"
+                        if allow_resample
+                        else " (resample disabled)"
+                    )
+                )
+            print(f"    {target.name}: {line}")
+        except Exception as exc:  # noqa: BLE001 - keep probing the rest
+            print(f"    {target.name}: FAILED ({exc})")
+        finally:
+            dub_tmp.unlink(missing_ok=True)
+    print()
+
+
+def _print_summary(outcomes: List[FileOutcome]) -> None:
+    done = sum(1 for o in outcomes if o.status == "done")
+    skipped = sum(1 for o in outcomes if o.status == "skipped")
+    failed = [o for o in outcomes if o.status == "failed"]
+    print(
+        f"\nDubSync finished: {done} done, {skipped} skipped, {len(failed)} failed"
+    )
+    for o in failed:
+        print(f"  FAILED  {o.path.name}: {o.detail}")
+    print()
+
+
+def run_dubsync(
+    source,
+    target_dir,
+    offset: Optional[float] = None,
+    audio_language: str = "German Dub",
+    recursive: bool = False,
+    dry_run: bool = False,
+    cleanup: bool = False,
+    overwrite: bool = False,
+    auto_align: bool = True,
+    allow_resample: bool = False,
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    selected: Optional[Iterable[Tuple[Optional[int], int]]] = None,
+    explicit: Optional[Iterable[Tuple[Optional[int], int, str]]] = None,
+) -> Tuple[MatchReport, List[FileOutcome]]:
+    """Run DubSync over ``target_dir`` against ``source``.
+
+    Args:
+        source: AniWorld/SerienStream URL string, or a series/season/episode
+            model object (anything the matcher accepts).
+        target_dir: directory of archive-quality videos to enrich.
+        offset: manual dub delay in seconds (negative allowed). ``None`` means
+            detect per episode when ``auto_align`` is on (else 0); an explicit
+            value always overrides detection.
+        audio_language: source language label to graft (default German Dub).
+        recursive: descend into subdirectories when scanning.
+        dry_run: print the match report (and, with auto-align, the detected
+            per-episode offsets) without writing to any target file.
+        cleanup: edit files in place (temp + atomic replace) instead of writing
+            a ``*.dubsync.<ext>`` sidecar copy.
+        overwrite: re-graft even if the target already carries the dub language.
+        auto_align: detect each episode's offset via music/SFX-bed correlation.
+        allow_resample: when linear drift is detected (e.g. PAL-sourced dub),
+            correct it with ``atempo`` -- this re-encodes the dub track only.
+        min_confidence: correlation peak z-score below which a detection is
+            discarded in favour of offset 0 (and flagged in the report).
+        selected: restrict the run to these ``(season, episode)`` keys
+            (``None`` processes every episode the matcher pairs).
+        explicit: user-confirmed ``(season, episode, filename)`` triples for
+            movies, whose filenames carry no parsable episode pattern.
+
+    Returns ``(match_report, outcomes)``.
+    """
+
+    report = match_directory(
+        target_dir, source, recursive=recursive, selected=selected, explicit=explicit
+    )
+    audio_code = _resolve_audio_code(audio_language)
+
+    _print_report(report, target_dir)
+
+    outcomes: List[FileOutcome] = []
+    use_auto_align = auto_align and offset is None
+
+    if dry_run:
+        if use_auto_align and report.pairs:
+            tmp_dir = Path(tempfile.mkdtemp(prefix="dubsync_"))
+            try:
+                _dry_run_align(
+                    report.pairs,
+                    tmp_dir,
+                    audio_language,
+                    audio_code,
+                    allow_resample,
+                    min_confidence,
+                )
+            finally:
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+        logger.info("[DUBSYNC] dry-run: no files written")
+        return report, outcomes
+
+    if not report.pairs:
+        logger.info("[DUBSYNC] nothing to do (no matched files)")
+        return report, outcomes
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="dubsync_"))
+    try:
+        for pf, episode in report.pairs:
+            target = pf.path
+            try:
+                check = check_downloaded(target)
+                if audio_code in check["audio_langs"] and not overwrite:
+                    logger.info(
+                        f"[DUBSYNC] skip (already has '{audio_code}'): {target.name}"
+                    )
+                    outcomes.append(
+                        FileOutcome(
+                            target, "skipped", f"'{audio_code}' track already present"
+                        )
+                    )
+                    continue
+
+                dub_tmp = tmp_dir / f"{target.stem}.{audio_code}.mka"
+                extract_dub_audio(
+                    episode, dub_tmp, audio_language=audio_language, label=target.stem
+                )
+
+                detail = ""
+                dub_path = dub_tmp
+                if use_auto_align:
+                    use_offset, dub_path, detail = _align_dub(
+                        dub_tmp, target, allow_resample, min_confidence
+                    )
+                else:
+                    use_offset = offset if offset is not None else 0.0
+
+                if cleanup:
+                    out = target
+                else:
+                    out = target.with_name(f"{target.stem}.dubsync{target.suffix}")
+
+                remux_with_dub(
+                    target,
+                    dub_path,
+                    out,
+                    offset=use_offset,
+                    audio_code=audio_code,
+                    label=target.stem,
+                )
+
+                if dub_path != dub_tmp:
+                    dub_path.unlink(missing_ok=True)
+                dub_tmp.unlink(missing_ok=True)
+                outcomes.append(FileOutcome(out, "done", detail))
+                logger.info(f"[DUBSYNC] done: {out.name}")
+
+            except Exception as exc:  # noqa: BLE001 - report per-file, keep going
+                logger.warning(f"[DUBSYNC] failed for {target.name}: {exc}")
+                outcomes.append(FileOutcome(target, "failed", str(exc)))
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    _print_summary(outcomes)
+    return report, outcomes

--- a/src/aniworld/models/aniworld_to/dubsync/remux.py
+++ b/src/aniworld/models/aniworld_to/dubsync/remux.py
@@ -1,0 +1,128 @@
+"""Graft a dub audio track into a target video container losslessly.
+
+Takes an archive-quality video (all its streams) plus a standalone dub audio
+file and produces an output with the dub appended as a secondary,
+language-tagged audio track. Everything is stream-copied (``-c copy``); the only
+timing adjustment is a constant ``-itsoffset`` on the dub input, which stays
+lossless. Container differences are reconciled by :func:`_finalize_episode`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ffmpeg
+
+from ....config import logger
+from ...common.common import _finalize_episode, _run_ffmpeg_with_progress
+
+
+def _count_audio_streams(path: Path) -> int:
+    """Number of audio streams already in *path* (probe-based).
+
+    Used to place the appended dub at the correct output audio index for the
+    ``-metadata:s:a:N`` / ``-disposition:a:N`` specifiers. Raises rather than
+    guessing, since a wrong index would mis-tag an archive file.
+    """
+
+    try:
+        probe = ffmpeg.probe(str(path))
+    except ffmpeg.Error as exc:
+        raise RuntimeError(f"Could not probe target video: {path}") from exc
+
+    return sum(
+        1 for s in probe.get("streams", []) if s.get("codec_type") == "audio"
+    )
+
+
+def remux_with_dub(
+    target_video,
+    dub_audio,
+    output_path,
+    offset: float = 0.0,
+    audio_code: str = "deu",
+    label: str = "",
+):
+    """Mux ``target_video`` + ``dub_audio`` -> ``output_path``.
+
+    Stream order in the output is: all of the target's streams first, then the
+    dub audio appended (``-map 0 -map 1:a``). The dub is tagged
+    ``language=<audio_code>`` and has its default disposition cleared so players
+    keep the original track primary. ``offset`` (seconds, may be negative)
+    delays the dub via ``-itsoffset``.
+
+    Writes to a temp MKV next to ``output_path`` then atomically finalises onto
+    it, so an interrupted run never corrupts the archive file.
+    """
+
+    target_video = Path(target_video)
+    dub_audio = Path(dub_audio)
+    output_path = Path(output_path)
+
+    num_audio = _count_audio_streams(target_video)
+
+    video_in = ffmpeg.input(str(target_video))
+
+    dub_input_kwargs = {}
+    if offset:
+        dub_input_kwargs["itsoffset"] = float(offset)
+    dub_in = ffmpeg.input(str(dub_audio), **dub_input_kwargs)
+
+    output_kwargs = {
+        "c": "copy",
+        f"metadata:s:a:{num_audio}": f"language={audio_code}",
+        # Keep the original audio as the default track; the dub is secondary.
+        f"disposition:a:{num_audio}": "0",
+    }
+
+    temp_path = output_path.with_name(f"{output_path.stem}.dubsync.new.mkv")
+    temp_attach = output_path.with_name(f"{output_path.stem}.dubsync.attach.mkv")
+
+    logger.debug(
+        f"[DUBSYNC] muxing dub (offset={offset}s, tag={audio_code}, "
+        f"stream a:{num_audio}) -> {output_path.name}"
+    )
+
+    # ffmpeg (observed on 8.1) badly mis-interleaves the second input's
+    # packets in a multi-input stream copy: the dub lands hundreds of MB
+    # later in the file than its timestamp peers (or entirely at the end when
+    # attachments are mapped) -- players then find no dub audio in their
+    # readahead window and play silence. So the mux is done in two passes:
+    #
+    # 1. Combine target streams (minus attachments, which worsen the skew)
+    #    with the offset dub. The result is correct but poorly interleaved.
+    # 2. Re-interleave in a single-input copy with -max_interleave_delta 0,
+    #    which buffers until every stream is present and writes strictly by
+    #    timestamp; the target's font attachments are re-added in the same
+    #    pass (an attachments-only extra input carries no packets and cannot
+    #    skew anything).
+    node = ffmpeg.output(
+        video_in["v?"],
+        video_in["a?"],
+        video_in["s?"],
+        video_in["d?"],
+        dub_in.audio,
+        str(temp_path),
+        **output_kwargs,
+    )
+
+    try:
+        _run_ffmpeg_with_progress(node, label=label)
+
+        logger.debug(f"[DUBSYNC] re-interleaving -> {output_path.name}")
+        interleave_node = ffmpeg.output(
+            ffmpeg.input(str(temp_path)),
+            ffmpeg.input(str(target_video))["t?"],
+            str(temp_attach),
+            c="copy",
+            max_interleave_delta="0",
+        )
+        _run_ffmpeg_with_progress(interleave_node, label=label)
+        temp_path.unlink(missing_ok=True)
+
+        _finalize_episode(temp_attach, output_path, label)
+    finally:
+        temp_path.unlink(missing_ok=True)
+        temp_attach.unlink(missing_ok=True)
+
+    return output_path

--- a/src/aniworld/models/aniworld_to/dubsync/subfetch.py
+++ b/src/aniworld/models/aniworld_to/dubsync/subfetch.py
@@ -1,0 +1,415 @@
+"""Fetch real (soft) subtitle tracks for anime episodes from Animetosho.
+
+AniWorld's "Sub" variants are hardsubbed video encodes, so a togglable
+subtitle track can never come from the streaming hosters themselves. It can,
+however, come from the fansub scene: Erai-raws MultiSub releases carry the
+official Crunchyroll subtitles in many languages (German included), and
+Animetosho extracts every subtitle stream from those releases and serves each
+one individually - no API key, no rate-limited account.
+
+Flow: resolve the episode's season to its MAL id (AniWorld already maps
+seasons to MAL for AniSkip) -> Jikan gives the romaji title Erai-raws names
+its files after -> Animetosho JSON search for that title + episode number ->
+pick the subtitle attachment in the wanted language -> download + un-xz ->
+optionally time-align with ffsubsync -> mux as a non-default subtitle track
+(MKV) or drop a sidecar file next to the video (other containers).
+"""
+
+from __future__ import annotations
+
+import lzma
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import ffmpeg
+import niquests
+
+from ....aniskip.jikan import get_anime_titles
+from ....config import DEFAULT_USER_AGENT, logger
+
+# Plain requests instead of GLOBAL_SESSION: the shared session advertises
+# compression encodings Animetosho answers with but niquests then fails to
+# decode, yielding undecodable JSON bodies.
+_HEADERS = {"User-Agent": DEFAULT_USER_AGENT, "Accept-Encoding": "gzip"}
+
+FEED_URL = "https://feed.animetosho.org/json"
+# Attachment ids from the JSON API map to storage URLs with the id in hex;
+# the filename part is free-form, only the extension chain matters.
+ATTACH_URL = "https://animetosho.org/storage/attach/{aid:08x}/subtitle.{lang}.{ext}.xz"
+
+MIN_TITLE_SCORE = 0.85
+
+# Accepted spellings for --fetch-subs values -> Animetosho's ISO 639-2/B codes.
+LANG_ALIASES = {
+    "1": "ger",
+    "true": "ger",
+    "yes": "ger",
+    "on": "ger",
+    "de": "ger",
+    "deu": "ger",
+    "ger": "ger",
+    "german": "ger",
+    "en": "eng",
+    "eng": "eng",
+    "english": "eng",
+    "fr": "fre",
+    "fra": "fre",
+    "fre": "fre",
+    "french": "fre",
+    "es": "spa",
+    "spa": "spa",
+    "spanish": "spa",
+    "it": "ita",
+    "ita": "ita",
+    "italian": "ita",
+    "pt": "por",
+    "por": "por",
+    "portuguese": "por",
+    "ru": "rus",
+    "rus": "rus",
+    "russian": "rus",
+    "ar": "ara",
+    "ara": "ara",
+    "arabic": "ara",
+}
+
+_SUB_EXTENSIONS = {"ass": "ass", "ssa": "ssa", "srt": "srt", "subrip": "srt"}
+
+
+def _tokens(text):
+    # "wo" vs "o" is the most common romanization difference in release names
+    # (e.g. "Yume wo Minai" vs "Yume o Minai") - fold it away.
+    return {
+        "o" if t == "wo" else t
+        for t in re.split(r"[^a-z0-9]+", text.lower())
+        if t
+    }
+
+
+def _episode_re(episode_number):
+    return re.compile(rf"\s-\s0*{episode_number}(?:v\d+)?\b")
+
+
+def _title_score(release_title, wanted_title, episode_number):
+    """Similarity in [0, 1]; strict enough to reject sibling seasons.
+
+    Uses the *minimum* directional token containment: sequel seasons share
+    most of their tokens ("Seishun Buta Yarou wa ... no Yume o Minai"), so a
+    symmetric Dice score would happily match the wrong season. Requiring both
+    titles to be nearly covered by the other keeps only the actual season.
+    """
+    clean = re.sub(r"\[[^\]]*\]|\([^)]*\)", " ", release_title)
+    clean = re.split(rf"\s-\s0*{episode_number}\b", clean)[0]
+    release_tokens = _tokens(clean)
+    wanted_tokens = _tokens(wanted_title)
+    if not release_tokens or not wanted_tokens:
+        return 0.0
+    shared = len(release_tokens & wanted_tokens)
+    return min(shared / len(wanted_tokens), shared / len(release_tokens))
+
+
+def _get_json(params):
+    res = niquests.get(FEED_URL, params=params, headers=_HEADERS, timeout=30)
+    res.raise_for_status()
+    return res.json()
+
+
+def _pick_attachment(tosho_id, episode_number, lang3):
+    """Return (attachment_id, extension) of the wanted subtitle, or None."""
+    detail = _get_json({"show": "torrent", "id": tosho_id})
+    files = detail.get("files") or []
+    ep_re = _episode_re(episode_number)
+    for file_entry in files:
+        # Batch torrents hold many episodes; match ours by filename then.
+        if len(files) > 1 and not ep_re.search(file_entry.get("filename") or ""):
+            continue
+        for attachment in file_entry.get("attachments") or []:
+            info = attachment.get("info") or {}
+            if attachment.get("type") != "subtitle":
+                continue
+            if info.get("lang") != lang3 or info.get("forced"):
+                continue
+            ext = _SUB_EXTENSIONS.get((info.get("codec") or "ass").lower())
+            if ext and attachment.get("id"):
+                return attachment["id"], ext
+    return None
+
+
+def _find_subtitle(titles, episode_number, lang3):
+    """Search Animetosho for the episode; return (attachment_id, ext, release)."""
+    ep_re = _episode_re(episode_number)
+    seen_ids = set()
+    for title in titles:
+        for query in (
+            f"Erai-raws {title} - {episode_number:02d}",
+            f"Erai-raws {title}",
+        ):
+            try:
+                results = _get_json({"q": query})
+            except Exception as exc:
+                logger.debug(f"[SUBS] Animetosho search failed ({exc})")
+                continue
+            if not isinstance(results, list):
+                continue
+
+            candidates = []
+            for entry in results:
+                release_title = entry.get("title") or ""
+                if not release_title.lower().startswith("[erai-raws]"):
+                    continue
+                if not ep_re.search(release_title):
+                    continue
+                score = _title_score(release_title, title, episode_number)
+                if score >= MIN_TITLE_SCORE:
+                    candidates.append((score, entry))
+
+            candidates.sort(key=lambda item: item[0], reverse=True)
+            for _score, entry in candidates[:5]:
+                tosho_id = entry.get("id")
+                if not tosho_id or tosho_id in seen_ids:
+                    continue
+                seen_ids.add(tosho_id)
+                try:
+                    picked = _pick_attachment(tosho_id, episode_number, lang3)
+                except Exception as exc:
+                    logger.debug(f"[SUBS] torrent detail failed ({exc})")
+                    continue
+                if picked:
+                    return picked[0], picked[1], entry.get("title") or ""
+            if candidates:
+                # Right releases found but none carries the language; other
+                # queries for the same series will hit the same releases.
+                return None
+    return None
+
+
+def _download_attachment(attachment_id, lang3, ext, dest):
+    url = ATTACH_URL.format(aid=attachment_id, lang=lang3, ext=ext)
+    res = niquests.get(url, headers=_HEADERS, timeout=60)
+    res.raise_for_status()
+    dest.write_bytes(lzma.decompress(res.content))
+
+
+def _align_subtitle(video_path, sub_path, label=""):
+    """Time-align the subtitle to the video via ffsubsync when available."""
+    ffsubsync_bin = shutil.which("ffsubsync")
+    if ffsubsync_bin:
+        cmd = [ffsubsync_bin]
+    else:
+        try:
+            import ffsubsync  # noqa: F401
+        except ImportError:
+            logger.info(
+                "[SUBS] ffsubsync not installed - muxing subtitle with its "
+                "original timing (pip install ffsubsync to auto-sync it)"
+            )
+            return sub_path
+        cmd = [sys.executable, "-m", "ffsubsync"]
+
+    synced = sub_path.with_name(f"{sub_path.stem}.synced{sub_path.suffix}")
+    cmd += [str(video_path), "-i", str(sub_path), "-o", str(synced)]
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=600,
+            check=False,
+        )
+        if proc.returncode == 0 and synced.exists() and synced.stat().st_size:
+            logger.debug(f"[SUBS] ffsubsync aligned subtitle for {label}")
+            return synced
+        logger.warning(
+            f"[SUBS] ffsubsync failed (rc={proc.returncode}); "
+            "keeping original subtitle timing"
+        )
+    except Exception as exc:
+        logger.warning(
+            f"[SUBS] ffsubsync error ({exc}); keeping original subtitle timing"
+        )
+    synced.unlink(missing_ok=True)
+    return sub_path
+
+
+def _has_subtitle_lang(path, lang3):
+    try:
+        probe = ffmpeg.probe(str(path))
+    except ffmpeg.Error:
+        return False
+    for stream in probe.get("streams", []):
+        if stream.get("codec_type") != "subtitle":
+            continue
+        if stream.get("tags", {}).get("language") == lang3:
+            return True
+    return False
+
+
+def _mux_subtitle_track(target_path, sub_path, lang3, label=""):
+    """Stream-copy *sub_path* into the MKV as a non-default subtitle track."""
+    from ...common.common import _finalize_episode, _run_ffmpeg_with_progress
+
+    try:
+        probe = ffmpeg.probe(str(target_path))
+        num_subs = sum(
+            1
+            for s in probe.get("streams", [])
+            if s.get("codec_type") == "subtitle"
+        )
+    except ffmpeg.Error as exc:
+        raise RuntimeError(f"Could not probe {target_path}") from exc
+
+    inp = ffmpeg.input(str(target_path))
+    sub_in = ffmpeg.input(str(sub_path))
+    output_kwargs = {
+        "c": "copy",
+        f"metadata:s:s:{num_subs}": f"language={lang3}",
+        f"disposition:s:{num_subs}": "0",
+    }
+
+    temp_path = target_path.with_name(f"{target_path.stem}.subfetch.new.mkv")
+    node = ffmpeg.output(
+        inp["v?"],
+        inp["a?"],
+        inp["s?"],
+        inp["d?"],
+        inp["t?"],
+        sub_in["s?"],
+        str(temp_path),
+        **output_kwargs,
+    )
+    try:
+        _run_ffmpeg_with_progress(node, label=label)
+        _finalize_episode(temp_path, target_path, label)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def fetch_and_mux_subtitle(episode, target_path, lang="ger", label=""):
+    """Fetch a soft subtitle for *episode* and attach it to *target_path*.
+
+    Returns the path that received the subtitle (the video itself for MKV, a
+    sidecar file otherwise) or None when no subtitle could be added. Raises
+    only for programmer errors; expected misses just log and return None.
+    """
+    target_path = Path(target_path)
+    lang3 = LANG_ALIASES.get((lang or "").strip().lower())
+    if not lang3:
+        logger.warning(f"[SUBS] unknown subtitle language {lang!r}")
+        return None
+
+    url = (getattr(episode, "url", "") or "").lower()
+    if "aniworld.to" not in url:
+        logger.info(
+            f"[SUBS] skipping {label or target_path.name}: subtitle fetching "
+            "covers anime only (Erai-raws/Animetosho)"
+        )
+        return None
+    if not target_path.exists():
+        return None
+
+    is_mkv = target_path.suffix.lower() == ".mkv"
+    if is_mkv and _has_subtitle_lang(target_path, lang3):
+        logger.debug(f"[SUBS] {label} already has a '{lang3}' subtitle track")
+        return None
+    if not is_mkv and any(
+        target_path.with_name(f"{target_path.stem}.{lang3}.{ext}").exists()
+        for ext in ("ass", "ssa", "srt")
+    ):
+        logger.debug(f"[SUBS] {label} already has a '{lang3}' subtitle sidecar")
+        return None
+
+    try:
+        season_number = episode.season.season_number
+        episode_number = episode.episode_number
+    except Exception:
+        season_number, episode_number = None, None
+    if not episode_number or not season_number or season_number < 1:
+        logger.info(
+            f"[SUBS] skipping {label or target_path.name}: "
+            "no season/episode numbering (movies are not supported yet)"
+        )
+        return None
+
+    # Per-season MAL titles are the most reliable (scene releases are named
+    # after them), but Jikan is flaky — the AniWorld page's own alternative
+    # titles (which include the romaji name) work as a fallback.
+    titles = []
+    try:
+        mal_ids = episode.series.mal_id or []
+        if season_number <= len(mal_ids):
+            titles = get_anime_titles(mal_ids[season_number - 1])
+    except Exception as exc:
+        logger.debug(f"[SUBS] MAL title lookup failed ({exc})")
+
+    series = getattr(episode, "series", None)
+    base_titles = []
+    try:
+        for alt in series.alternative_titles or []:
+            if alt not in base_titles:
+                base_titles.append(alt)
+    except Exception as exc:
+        logger.debug(f"[SUBS] alternative titles unavailable ({exc})")
+    series_title = getattr(series, "title", None)
+    if series_title and series_title not in base_titles:
+        base_titles.append(series_title)
+
+    if season_number == 1:
+        for base in base_titles:
+            if base not in titles:
+                titles.append(base)
+    elif not titles:
+        # Sequel season without a MAL name: guess the scene naming, which
+        # follows MAL's "<title> 2nd Season" / "<title> Season 2" style.
+        ordinal = {1: "1st", 2: "2nd", 3: "3rd"}.get(
+            season_number, f"{season_number}th"
+        )
+        for base in base_titles:
+            for suffix in (f"{ordinal} Season", f"Season {season_number}"):
+                candidate = f"{base} {suffix}"
+                if candidate not in titles:
+                    titles.append(candidate)
+
+    titles = titles[:8]
+    if not titles:
+        logger.info(f"[SUBS] no searchable titles for {label}")
+        return None
+
+    found = _find_subtitle(titles, episode_number, lang3)
+    if not found:
+        logger.info(
+            f"[SUBS] no '{lang3}' subtitle found for {label or target_path.name} "
+            "(older shows often predate Erai-raws MultiSub releases)"
+        )
+        return None
+    attachment_id, ext, release_title = found
+
+    raw_sub = target_path.with_name(f"{target_path.stem}.{lang3}.{ext}")
+    _download_attachment(attachment_id, lang3, ext, raw_sub)
+    logger.info(f"[SUBS] fetched '{lang3}' subtitle from {release_title}")
+
+    try:
+        synced_sub = _align_subtitle(target_path, raw_sub, label)
+
+        if is_mkv:
+            _mux_subtitle_track(target_path, synced_sub, lang3, label)
+            logger.info(
+                f"[SUBS] added '{lang3}' subtitle track to {target_path.name}"
+            )
+            return target_path
+
+        # Non-MKV containers can't hold ASS; leave an aligned sidecar file
+        # that players pick up automatically.
+        if synced_sub != raw_sub:
+            os.replace(synced_sub, raw_sub)
+        logger.info(f"[SUBS] wrote subtitle sidecar {raw_sub.name}")
+        return raw_sub
+    finally:
+        if is_mkv:
+            raw_sub.unlink(missing_ok=True)
+            synced = raw_sub.with_name(f"{raw_sub.stem}.synced{raw_sub.suffix}")
+            synced.unlink(missing_ok=True)

--- a/src/aniworld/models/aniworld_to/series.py
+++ b/src/aniworld/models/aniworld_to/series.py
@@ -50,6 +50,7 @@ class AniworldSeries:
         # Extracted from self.html
         self.__title = None
         self.__title_cleaned = None
+        self.__alternative_titles = None
         self.__description = None
         self.__genres = None
         self.__release_year = None
@@ -106,6 +107,18 @@ class AniworldSeries:
         if self.__title_cleaned is None:
             self.__title_cleaned = clean_title(self.title)
         return self.__title_cleaned
+
+    @property
+    def alternative_titles(self):
+        """Alternate names from the page's data-alternativeTitles attribute.
+
+        Usually includes the romaji title (e.g. "Sousou no Frieren"), which
+        scene releases are named after — the subtitle fetcher relies on it
+        when the MAL lookup is unavailable.
+        """
+        if self.__alternative_titles is None:
+            self.__alternative_titles = self.__extract_alternative_titles()
+        return self.__alternative_titles
 
     @property
     def description(self):
@@ -205,6 +218,19 @@ class AniworldSeries:
         from ...aniskip import get_all_seasons_by_query
 
         return get_all_seasons_by_query(self.title)
+
+    def __extract_alternative_titles(self):
+        match = re.search(
+            r'data-alternativeTitles="([^"]*)"', self._html, re.IGNORECASE
+        )
+        if not match:
+            return []
+        titles = []
+        for part in unescape(match.group(1)).split(","):
+            part = part.strip()
+            if part and part not in titles:
+                titles.append(part)
+        return titles
 
     def __extract_title(self):
         """

--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -384,13 +384,23 @@ def _run_ffmpeg_with_progress(node, overwrite_output=True, label=""):
     # Use shorter stats_period for smoother progress (1s in non-debug, 10s in debug)
     stats_period = "10" if debug_mode else "1"
 
-    args = ffmpeg.compile(node, overwrite_output=overwrite_output)
+    # Global options must come before the inputs/outputs: ffmpeg silently
+    # discards anything after the last output filename as "trailing options".
+    # ffmpeg-python appends -y at the very end, so compiling with
+    # overwrite_output=True never actually enabled overwriting -- a
+    # pre-existing output then blocks on ffmpeg's interactive prompt until
+    # the stall killer SIGKILLs the process.
+    args = ffmpeg.compile(node, overwrite_output=False)
+    head = []
     if "-stats_period" not in args:
-        args.insert(-1, "-stats_period")
-        args.insert(-1, stats_period)
+        head += ["-stats_period", stats_period]
+    if overwrite_output and "-y" not in args:
+        head.append("-y")
+    args[1:1] = head
 
     process = subprocess.Popen(
         args,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         universal_newlines=False,
@@ -610,10 +620,21 @@ def _finalize_episode(temp_path, episode_path, label=""):
     if target_ext == "mp4":
         output_kwargs["movflags"] = "+faststart"
 
+    # Map streams explicitly: without -map, ffmpeg's default selection keeps
+    # only ONE audio stream ("best" = highest channel count), which silently
+    # dropped DubSync's appended dub track on every mkv -> mp4 conversion.
+    # MP4 can't stream-copy Matroska subtitle/attachment formats, so only
+    # video + all audio go there; mkv keeps everything.
+    inp = ffmpeg.input(str(temp_path))
+    if target_ext == "mp4":
+        copy_streams = [inp["v?"], inp["a?"]]
+    else:
+        copy_streams = [inp["v?"], inp["a?"], inp["s?"], inp["d?"], inp["t?"]]
+
     try:
         logger.debug(f"[REMUXING] {source_ext} -> {target_ext}")
         _run_ffmpeg_with_progress(
-            ffmpeg.input(str(temp_path)).output(str(converted), **output_kwargs),
+            ffmpeg.output(*copy_streams, str(converted), **output_kwargs),
             label=label,
         )
     except RuntimeError:
@@ -624,7 +645,9 @@ def _finalize_episode(temp_path, episode_path, label=""):
         )
         converted.unlink(missing_ok=True)
         _run_ffmpeg_with_progress(
-            ffmpeg.input(str(temp_path)).output(
+            ffmpeg.output(
+                inp["v?"],
+                inp["a?"],
                 str(converted),
                 vcodec="libx264",
                 preset="veryfast",
@@ -638,6 +661,212 @@ def _finalize_episode(temp_path, episode_path, label=""):
 
     os.replace(converted, episode_path)
     temp_path.unlink(missing_ok=True)
+
+
+def _env_flag(name, default=False):
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+# Two encodes of the same episode start within seconds of each other. A wider
+# search only invites a noise peak minutes away from the truth to win.
+_MERGE_MAX_OFFSET = 60.0
+
+
+def _detect_merge_offset(new_path, existing_path, what, retime_to=None):
+    """Work out how to line *new_path* up with *existing_path*.
+
+    Returns ``(offset_seconds, retimed_path_or_None)``. Reuses DubSync's
+    music/SFX cross-correlation. Returns ``(0.0, None)`` — the plain unshifted
+    merge — whenever alignment is disabled, unconfident, or impossible, since
+    the merge itself must never break because of alignment.
+
+    Two encodes of the same episode can differ in *speed*, not just start
+    time: a German TV dub is usually PAL (25 fps) while the original-language
+    encode is film rate (23.976), which makes the dub run ~4 % fast. No
+    constant shift can fix that, and the constant offset measured under that
+    assumption is meaningless — applying it anyway is how a track ended up
+    minutes out of sync. Drift is therefore only ever corrected by retiming
+    the audio (when *retime_to* gives somewhere to write it), never by
+    shifting.
+    """
+    if not _env_flag("ANIWORLD_MERGE_ALIGN", default=True):
+        return 0.0, None
+    try:
+        from ..aniworld_to.dubsync.align import (
+            DEFAULT_MIN_CONFIDENCE,
+            detect_offset,
+            resample_dub,
+        )
+
+        result = detect_offset(
+            new_path, existing_path, max_offset=_MERGE_MAX_OFFSET
+        )
+
+        if result.has_drift:
+            drift_note = (
+                f"{what} runs at a different speed "
+                f"(atempo {result.tempo_ratio:.5f}, "
+                f"drift {result.drift:+.1f}s over the episode)"
+            )
+            if retime_to is None:
+                logger.warning(
+                    f"[MERGE] {drift_note}; its video cannot be retimed, so it "
+                    "is merged unshifted — sync will wander"
+                )
+                return 0.0, None
+            if not _env_flag("ANIWORLD_MERGE_RESAMPLE", default=True):
+                logger.warning(
+                    f"[MERGE] {drift_note}; retiming is disabled, so it is "
+                    "merged unshifted — sync will wander"
+                )
+                return 0.0, None
+
+            # Retiming decodes and re-encodes, but only the freshly added
+            # track: the existing file's streams are never touched.
+            resample_dub(
+                new_path,
+                retime_to,
+                result.tempo_ratio,
+                label=str(what),
+                acodec="aac",
+            )
+            offset = round(result.post_tempo_offset, 3)
+            logger.debug(
+                f"[MERGE] {drift_note}; retimed, then offset {offset:+.3f}s "
+                f"(confidence {result.drift_confidence:.1f})"
+            )
+            return offset, retime_to
+
+        if result.confidence >= DEFAULT_MIN_CONFIDENCE:
+            offset = round(result.offset, 3)
+            logger.debug(
+                f"[MERGE] {what} aligned: offset {offset:+.3f}s "
+                f"(confidence {result.confidence:.1f})"
+            )
+            return offset, None
+
+        logger.warning(
+            f"[MERGE] could not confidently align {what} "
+            f"(confidence {result.confidence:.1f}); merging without shift"
+        )
+    except Exception as exc:
+        logger.warning(
+            f"[MERGE] alignment of {what} failed ({exc}); merging without shift"
+        )
+    return 0.0, None
+
+
+def _merge_audio_aligned(episode_path, temp_audio, audio_code, ep_label):
+    """Append *temp_audio* to *episode_path* as an aligned additional track.
+
+    Goes through DubSync's remux (itsoffset + language tag + non-default
+    disposition + re-interleave) so the new language stays in sync and players
+    keep the first track primary. Falls back to the plain concat merge if the
+    aligned mux itself fails.
+    """
+    retimed_path = temp_audio.with_suffix(".retimed.mka")
+    offset, retimed = _detect_merge_offset(
+        temp_audio,
+        episode_path,
+        f"new '{audio_code}' audio track",
+        retime_to=retimed_path,
+    )
+    try:
+        from ..aniworld_to.dubsync.remux import remux_with_dub
+
+        remux_with_dub(
+            episode_path,
+            retimed or temp_audio,
+            episode_path,
+            offset=offset,
+            audio_code=audio_code,
+            label=ep_label,
+        )
+        return
+    except Exception as exc:
+        logger.warning(
+            f"[MERGE] aligned mux failed ({exc}); falling back to plain merge"
+        )
+    finally:
+        retimed_path.unlink(missing_ok=True)
+
+    output_path = episode_path.with_suffix(".new.mkv")
+    _run_ffmpeg_with_progress(
+        ffmpeg.output(
+            ffmpeg.input(str(episode_path)),
+            ffmpeg.input(str(temp_audio)),
+            str(output_path),
+            c="copy",
+        ),
+        label=ep_label,
+    )
+    _finalize_episode(output_path, episode_path, ep_label)
+
+
+def _merge_full_stream_aligned(target_path, temp_full, ep_label):
+    """Merge a second full stream (video + audio) into an existing episode file.
+
+    Used when a language variant brings its own video (hardsubbed "Sub"
+    versions): its streams are appended to the same file as switchable
+    secondary tracks. The whole second input is shifted by the detected offset
+    (its video and audio stay in sync with each other) and the appended
+    streams lose their default flag so players keep playing the originals.
+    """
+    # No retime target: retiming the audio alone would desync it from the
+    # video it arrived with, so a speed-mismatched variant is merged unshifted.
+    offset, _ = _detect_merge_offset(
+        temp_full, target_path, "second full stream"
+    )
+    second_kwargs = {"itsoffset": offset} if offset else {}
+
+    output_kwargs = {"c": "copy"}
+    try:
+        spec_by_type = {"video": "v", "audio": "a", "subtitle": "s"}
+        counts = {ctype: 0 for ctype in spec_by_type}
+        for stream in ffmpeg.probe(str(target_path)).get("streams", []):
+            if stream.get("codec_type") in counts:
+                counts[stream["codec_type"]] += 1
+        for stream in ffmpeg.probe(str(temp_full)).get("streams", []):
+            spec = spec_by_type.get(stream.get("codec_type"))
+            if spec:
+                output_kwargs[f"disposition:{spec}:{counts[stream['codec_type']]}"] = "0"
+                counts[stream["codec_type"]] += 1
+    except ffmpeg.Error:
+        pass  # merge without disposition tweaks if probing fails
+
+    inputs = [
+        ffmpeg.input(str(target_path)),
+        ffmpeg.input(str(temp_full), **second_kwargs),
+    ]
+    output_path = target_path.with_suffix(".new.mkv")
+    _run_ffmpeg_with_progress(
+        ffmpeg.output(*inputs, str(output_path), **output_kwargs),
+        label=ep_label,
+    )
+    _finalize_episode(output_path, target_path, ep_label)
+
+
+def _maybe_fetch_subtitle(episode, target_path, ep_label):
+    """Fetch a real (soft) subtitle track for a finished episode when enabled.
+
+    Controlled by --fetch-subs / ANIWORLD_FETCH_SUBS. Never raises: a missing
+    subtitle must not fail a completed download.
+    """
+    lang = (os.getenv("ANIWORLD_FETCH_SUBS") or "").strip().lower()
+    if not lang or lang in ("0", "false", "no", "off"):
+        return
+    try:
+        from ..aniworld_to.dubsync.subfetch import fetch_and_mux_subtitle
+
+        fetch_and_mux_subtitle(episode, target_path, lang=lang, label=ep_label)
+    except Exception as exc:
+        logger.warning(
+            f"[SUBS] subtitle fetch failed for "
+            f"{ep_label or target_path.name}: {exc}"
+        )
 
 
 def _download_direct_http(episode_path, stream_url, file_name):
@@ -1052,10 +1281,10 @@ def download(self):
         _set_selected_provider(self, provider_name)
 
         for attempt in range(1, max_retries + 1):
+            target_path = self._episode_path
             try:
                 _reset_provider_resolution_cache(self)
                 stream_url = self.stream_url
-                check = check_downloaded(self._episode_path)
 
                 headers = PROVIDER_HEADERS_D.get(provider_name, {})
                 input_kwargs = {
@@ -1099,6 +1328,13 @@ def download(self):
                         None if wants_clean_video else LANG_CODE_MAP[sub_enum]
                     )
 
+                # Every language variant lands in ONE file: extra dubs as
+                # additional audio tracks, hardsubbed "Sub" variants as an
+                # additional (non-default) video+audio pair — all aligned.
+                # Users who want separate per-language files instead can put
+                # {language} into their naming template.
+                check = check_downloaded(target_path)
+
                 has_video = bool(check["video_langs"])
                 has_audio = audio_code in check["audio_langs"]
 
@@ -1110,15 +1346,18 @@ def download(self):
                 else:
                     need_video = False
 
-                if not need_audio and not need_video:
-                    logger.debug(f"[SKIPPED] {self._file_name}")
-                    return
-
-                os.makedirs(self._folder_path, exist_ok=True)
-
                 ep_label = (
                     os.path.splitext(self._file_name)[0] if self._file_name else ""
                 )
+
+                if not need_audio and not need_video:
+                    logger.debug(f"[SKIPPED] {self._file_name}")
+                    # Still give an already-complete file its subtitle track
+                    # when --fetch-subs is on (no-op if it already has one).
+                    _maybe_fetch_subtitle(self, target_path, ep_label)
+                    return
+
+                os.makedirs(self._folder_path, exist_ok=True)
 
                 full_stream_needed = need_audio and need_video
 
@@ -1128,9 +1367,9 @@ def download(self):
                 # track instead of the default one.
                 select_rendition = getattr(self, "_separate_audio_rendition", False)
 
-                temp_audio = self._episode_path.with_suffix(".temp_audio.mkv")
-                temp_video = self._episode_path.with_suffix(".temp_video.mkv")
-                temp_full = self._episode_path.with_suffix(".temp_full.mkv")
+                temp_audio = target_path.with_suffix(".temp_audio.mkv")
+                temp_video = target_path.with_suffix(".temp_video.mkv")
+                temp_full = target_path.with_suffix(".temp_full.mkv")
 
                 if full_stream_needed:
                     logger.debug(
@@ -1186,21 +1425,16 @@ def download(self):
                             audio_code,
                         )
 
-                    if self._episode_path.exists():
-                        inputs = [
-                            ffmpeg.input(str(self._episode_path)),
-                            ffmpeg.input(str(temp_full)),
-                        ]
-                        output_path = self._episode_path.with_suffix(".new.mkv")
-                        _run_ffmpeg_with_progress(
-                            ffmpeg.output(*inputs, str(output_path), c="copy")
+                    if target_path.exists():
+                        _merge_full_stream_aligned(
+                            target_path, temp_full, ep_label
                         )
-                        _finalize_episode(output_path, self._episode_path, ep_label)
                     else:
-                        _finalize_episode(temp_full, self._episode_path, ep_label)
+                        _finalize_episode(temp_full, target_path, ep_label)
 
                     if temp_full.exists():
                         temp_full.unlink()
+                    _maybe_fetch_subtitle(self, target_path, ep_label)
                     return
 
                 if need_audio:
@@ -1261,27 +1495,37 @@ def download(self):
                     )
 
                 logger.debug("[MUXING] combining streams")
-                inputs = (
-                    [ffmpeg.input(str(self._episode_path))]
-                    if self._episode_path.exists()
-                    else []
-                )
 
-                if need_audio:
-                    inputs.append(ffmpeg.input(str(temp_audio)))
-                if need_video:
-                    inputs.append(ffmpeg.input(str(temp_video)))
+                if target_path.exists() and need_audio and not need_video:
+                    # Second language into an existing file: align the new
+                    # track instead of blindly concatenating it (the old
+                    # behaviour left the added audio out of sync).
+                    _merge_audio_aligned(
+                        target_path, temp_audio, audio_code, ep_label
+                    )
+                else:
+                    inputs = (
+                        [ffmpeg.input(str(target_path))]
+                        if target_path.exists()
+                        else []
+                    )
 
-                output_path = self._episode_path.with_suffix(".new.mkv")
-                _run_ffmpeg_with_progress(
-                    ffmpeg.output(*inputs, str(output_path), c="copy")
-                )
-                _finalize_episode(output_path, self._episode_path, ep_label)
+                    if need_audio:
+                        inputs.append(ffmpeg.input(str(temp_audio)))
+                    if need_video:
+                        inputs.append(ffmpeg.input(str(temp_video)))
+
+                    output_path = target_path.with_suffix(".new.mkv")
+                    _run_ffmpeg_with_progress(
+                        ffmpeg.output(*inputs, str(output_path), c="copy")
+                    )
+                    _finalize_episode(output_path, target_path, ep_label)
 
                 for f in (temp_audio, temp_video):
                     if f.exists():
                         f.unlink()
 
+                _maybe_fetch_subtitle(self, target_path, ep_label)
                 return
 
             except KeyboardInterrupt:

--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -463,6 +463,109 @@ def _fetch_public_ip():
     raise RuntimeError(last_error or "Failed to resolve public IP")
 
 
+def _run_dubsync_queue_item(item):
+    """Process a ``source == "dubsync"`` queue job.
+
+    The job parameters (target dir, offset, toggles) live as a single JSON
+    object in the ``episodes`` column; the AniWorld/SerienStream URL is the
+    item's ``series_url``. Progress inside a file comes through the global
+    ffmpeg progress snapshot like normal downloads.
+    """
+    from ..models.aniworld_to.dubsync.pipeline import (
+        dubsync_env_defaults,
+        run_dubsync,
+    )
+
+    payload = json.loads(item["episodes"])
+    job = payload[0] if isinstance(payload, list) else payload
+    defaults = dubsync_env_defaults()
+
+    raw_offset = job.get("offset")
+    offset = float(raw_offset) if raw_offset not in (None, "") else None
+
+    raw_selected = job.get("episodes")
+    selected = None
+    if isinstance(raw_selected, list):
+        # an empty list is meaningful: movie-only jobs restrict episode
+        # matching to nothing and work purely off the explicit pairs
+        selected = [
+            (int(s) if s is not None else None, int(e)) for s, e in raw_selected
+        ]
+
+    raw_pairs = job.get("pairs")
+    explicit = None
+    if isinstance(raw_pairs, list) and raw_pairs:
+        explicit = [
+            (int(s) if s is not None else None, int(e), str(f))
+            for s, e, f in raw_pairs
+        ]
+
+    update_queue_progress(item["id"], 0, item.get("series_url") or "")
+    report, outcomes = run_dubsync(
+        item["series_url"],
+        job["target_dir"],
+        offset=offset,
+        audio_language=item.get("language") or defaults["audio_language"],
+        recursive=bool(job.get("recursive", False)),
+        cleanup=bool(job.get("cleanup", defaults["cleanup"])),
+        auto_align=bool(job.get("auto_align", defaults["auto_align"])),
+        allow_resample=bool(
+            job.get("allow_resample", defaults["allow_resample"])
+        ),
+        selected=selected,
+        explicit=explicit,
+    )
+
+    failed = [o for o in outcomes if o.status == "failed"]
+    errors = [{"url": str(o.path), "error": o.detail} for o in failed]
+    if not report.pairs:
+        errors.append(
+            {
+                "url": job["target_dir"],
+                "error": "No local files matched the source episodes",
+            }
+        )
+    if errors:
+        update_queue_errors(item["id"], json.dumps(errors))
+
+    update_queue_progress(item["id"], 1, "")
+    all_failed = bool(errors) and (not outcomes or len(failed) == len(outcomes))
+    set_queue_status(item["id"], "failed" if all_failed else "completed")
+
+
+# Env toggles that per-job options may override; the baseline is captured on
+# first use so jobs without options restore the server's own startup defaults.
+_JOB_ENV_KEYS = ("ANIWORLD_FETCH_SUBS", "ANIWORLD_MERGE_ALIGN")
+_JOB_ENV_BASELINE = {}
+
+
+def _apply_job_env(options):
+    """Apply per-job feature toggles for the queue worker.
+
+    episode.download() reads these env vars; the worker processes one job at
+    a time, so setting them per job is safe. Anything the job does not
+    override is restored to the server's baseline.
+    """
+    import os
+
+    if not _JOB_ENV_BASELINE:
+        for key in _JOB_ENV_KEYS:
+            _JOB_ENV_BASELINE[key] = os.environ.get(key)
+
+    overrides = {}
+    if options.get("fetch_subs"):
+        overrides["ANIWORLD_FETCH_SUBS"] = str(options["fetch_subs"])
+    if options.get("merge_align") is False:
+        overrides["ANIWORLD_MERGE_ALIGN"] = "0"
+
+    for key in _JOB_ENV_KEYS:
+        value = overrides.get(key, _JOB_ENV_BASELINE[key])
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
 def _queue_worker():
     """Single global worker that processes one download at a time."""
     while True:
@@ -484,8 +587,29 @@ def _queue_worker():
                 time.sleep(3)
                 continue
 
+            if item.get("source") == "dubsync":
+                try:
+                    _run_dubsync_queue_item(item)
+                except Exception as e:
+                    logger.error(f"DubSync job failed: {e}", exc_info=True)
+                    update_queue_errors(
+                        item["id"], json.dumps([{"url": "", "error": str(e)}])
+                    )
+                    set_queue_status(item["id"], "failed")
+                continue
+
             episodes = json.loads(item["episodes"])
             errors = []
+            primary_failures = 0
+
+            try:
+                job_options = (
+                    json.loads(item["options"]) if item.get("options") else {}
+                )
+            except Exception:
+                job_options = {}
+            _apply_job_env(job_options)
+            extra_languages = job_options.get("extra_languages") or []
 
             # Language separation: compute subfolder path if enabled
             import os
@@ -575,6 +699,34 @@ def _queue_worker():
                     _captcha_mod._local.queue_id = item["id"]
                     try:
                         episode.download()
+                        # Extra languages merge into the same file as
+                        # additional aligned audio tracks; hardsub variants
+                        # become their own language-labelled file.
+                        if extra_languages and prov.name in (
+                            "AniWorld",
+                            "SerienStream",
+                        ):
+                            for extra_lang in extra_languages:
+                                try:
+                                    extra_kwargs = dict(ep_kwargs)
+                                    extra_kwargs["selected_language"] = extra_lang
+                                    prov.episode_cls(**extra_kwargs).download()
+                                except Exception as extra_err:
+                                    logger.error(
+                                        f"Extra language '{extra_lang}' failed "
+                                        f"for {chapter_url}: {extra_err}"
+                                    )
+                                    errors.append(
+                                        {
+                                            "url": chapter_url,
+                                            "error": (
+                                                f"{extra_lang}: {extra_err}"
+                                            ),
+                                        }
+                                    )
+                                    update_queue_errors(
+                                        item["id"], json.dumps(errors)
+                                    )
                     finally:
                         _captcha_mod._local.queue_id = None
                 except Exception as e:
@@ -601,6 +753,7 @@ def _queue_worker():
                     except Exception:
                         pass
                     errors.append(err_entry)
+                    primary_failures += 1
                     update_queue_errors(item["id"], json.dumps(errors))
 
                 # Check for cancellation after each episode
@@ -617,8 +770,12 @@ def _queue_worker():
             # Only set final status if not already cancelled
             if not is_queue_cancelled(item["id"]):
                 update_queue_progress(item["id"], len(episodes), "")
+                # Extra-language failures stay visible in the error list but
+                # only failed primary downloads flip the job to "failed".
                 status = (
-                    "failed" if errors and len(errors) == len(episodes) else "completed"
+                    "failed"
+                    if primary_failures and primary_failures == len(episodes)
+                    else "completed"
                 )
                 set_queue_status(item["id"], status)
 
@@ -1849,9 +2006,40 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
         if not episodes:
             return jsonify({"error": "episodes list is required"}), 400
 
-        if (
-            language == "English Sub"
-            and os.environ.get("ANIWORLD_DISABLE_ENGLISH_SUB", "0") == "1"
+        # Per-job feature options (kept in the queue row so the worker can
+        # apply them to exactly this download).
+        options = {}
+
+        extra_languages = data.get("extra_languages") or []
+        if not isinstance(extra_languages, list):
+            return jsonify({"error": "extra_languages must be a list"}), 400
+        valid_langs = set(LANG_LABELS.values())
+        cleaned_extras = []
+        for extra in extra_languages:
+            extra = str(extra).strip()
+            if extra not in valid_langs:
+                return jsonify({"error": f"Unknown language: {extra}"}), 400
+            if extra != language and extra not in cleaned_extras:
+                cleaned_extras.append(extra)
+        if cleaned_extras:
+            options["extra_languages"] = cleaned_extras
+
+        fetch_subs = data.get("fetch_subs")
+        if fetch_subs:
+            from ..models.aniworld_to.dubsync.subfetch import LANG_ALIASES
+
+            fetch_subs = str(fetch_subs).strip().lower()
+            if fetch_subs not in LANG_ALIASES:
+                return jsonify(
+                    {"error": f"Unknown subtitle language: {fetch_subs}"}
+                ), 400
+            options["fetch_subs"] = LANG_ALIASES[fetch_subs]
+
+        english_sub_disabled = (
+            os.environ.get("ANIWORLD_DISABLE_ENGLISH_SUB", "0") == "1"
+        )
+        if english_sub_disabled and (
+            language == "English Sub" or "English Sub" in cleaned_extras
         ):
             return jsonify({"error": "English Sub downloads are disabled"}), 403
 
@@ -1875,8 +2063,244 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             provider,
             username,
             custom_path_id=custom_path_id,
+            options=options or None,
         )
         return jsonify({"queue_id": queue_id})
+
+    @app.route("/api/dubsync", methods=["POST"])
+    def api_dubsync():
+        """Enqueue a DubSync job: graft the URL's dub onto local video files."""
+        from ..models.aniworld_to.dubsync.pipeline import dubsync_env_defaults
+
+        data = request.get_json(silent=True) or {}
+        defaults = dubsync_env_defaults()
+
+        url = str(data.get("url") or "").strip().replace(
+            "://s.to", "://serienstream.to"
+        )
+        target_dir = str(data.get("target_dir") or "").strip() or defaults[
+            "target_dir"
+        ]
+
+        if not url:
+            return jsonify({"error": "url is required"}), 400
+        if not target_dir:
+            return jsonify({"error": "target_dir is required"}), 400
+        if not os.path.isdir(os.path.expanduser(target_dir)):
+            return jsonify({"error": f"Not a directory: {target_dir}"}), 400
+
+        try:
+            prov = resolve_provider(url)
+        except Exception:
+            prov = None
+        valid = prov is not None and (
+            (
+                prov.name in ("AniWorld", "SerienStream")
+                and (
+                    (prov.series_pattern and prov.series_pattern.fullmatch(url))
+                    or (prov.season_pattern and prov.season_pattern.fullmatch(url))
+                )
+            )
+            # movie sites: the movie page URL itself is the source
+            or (
+                prov.name in ("MegaKino", "FilmPalast")
+                and prov.series_pattern
+                and prov.series_pattern.fullmatch(url)
+            )
+        )
+        if not valid:
+            return jsonify(
+                {
+                    "error": "url must be an AniWorld/SerienStream series or "
+                    "season, or a MegaKino/FilmPalast movie"
+                }
+            ), 400
+
+        raw_offset = str(data.get("offset", "")).strip()
+        if raw_offset:
+            try:
+                float(raw_offset)
+            except ValueError:
+                return jsonify({"error": f"Invalid offset: {raw_offset}"}), 400
+
+        # Optional episode restriction from the DubSync page's checklist:
+        # a list of [season, episode] pairs. May be empty when the job is
+        # movie-only (pairs below carry the work instead).
+        raw_episodes = data.get("episodes")
+        selected = None
+        if raw_episodes is not None:
+            if not isinstance(raw_episodes, list):
+                return jsonify({"error": "episodes must be a list"}), 400
+            try:
+                selected = [
+                    [int(s) if s is not None else None, int(e)]
+                    for s, e in raw_episodes
+                ]
+            except (TypeError, ValueError):
+                return jsonify(
+                    {"error": "episodes must be [season, episode] pairs"}
+                ), 400
+
+        # Optional movie pairings: [season, episode, filename] triples, the
+        # filename being the user-confirmed local file for that movie.
+        raw_pairs = data.get("pairs")
+        pairs = None
+        if raw_pairs is not None:
+            if not isinstance(raw_pairs, list):
+                return jsonify({"error": "pairs must be a list"}), 400
+            try:
+                pairs = [
+                    [int(s) if s is not None else None, int(e), str(f)]
+                    for s, e, f in raw_pairs
+                ]
+            except (TypeError, ValueError):
+                return jsonify(
+                    {"error": "pairs must be [season, episode, filename] triples"}
+                ), 400
+            if any(not p[2] for p in pairs):
+                return jsonify({"error": "pairs must name a local file"}), 400
+
+        if raw_episodes is not None and not selected and not pairs:
+            return jsonify(
+                {"error": "select at least one episode or movie"}
+            ), 400
+
+        job = {
+            "target_dir": os.path.expanduser(target_dir),
+            "offset": raw_offset or None,
+            "auto_align": bool(data.get("auto_align", defaults["auto_align"])),
+            "allow_resample": bool(
+                data.get("allow_resample", defaults["allow_resample"])
+            ),
+            "cleanup": bool(data.get("cleanup", defaults["cleanup"])),
+            "recursive": bool(data.get("recursive", False)),
+            "episodes": selected,
+            "pairs": pairs,
+        }
+
+        username = None
+        if auth_enabled:
+            user = get_current_user()
+            if user:
+                username = (
+                    user.get("username")
+                    if isinstance(user, dict)
+                    else getattr(user, "username", None)
+                )
+
+        parts = [p for p in url.rstrip("/").split("/") if p]
+        slug = parts[-1]
+        if slug.startswith("staffel-") and len(parts) >= 2:
+            slug = f"{parts[-2]} {slug}"
+        # movie-site URLs: "12345-some-movie.html" -> "some-movie"
+        slug = re.sub(r"\.html?$", "", slug)
+        slug = re.sub(r"^\d+-", "", slug)
+        slug = slug.replace("-", " ").title()
+        queue_id = add_to_queue(
+            f"DubSync: {slug}",
+            url,
+            [job],
+            defaults["audio_language"],
+            "",
+            username,
+            source="dubsync",
+        )
+        _ensure_queue_worker()
+        return jsonify({"queue_id": queue_id})
+
+    @app.route("/api/dubsync/browse")
+    def api_dubsync_browse():
+        """List subdirectories of a path for the DubSync folder picker."""
+        from pathlib import Path
+
+        from ..models.aniworld_to.dubsync.matcher import VIDEO_EXTENSIONS
+
+        raw = request.args.get("path", "").strip()
+        path = Path(os.path.expanduser(raw)) if raw else Path.home()
+        try:
+            path = path.resolve()
+        except OSError as exc:
+            return jsonify({"error": str(exc)}), 400
+        if not path.is_dir():
+            return jsonify({"error": f"Not a directory: {path}"}), 400
+
+        dirs = []
+        video_count = 0
+        try:
+            entries = sorted(path.iterdir(), key=lambda p: p.name.lower())
+        except PermissionError:
+            return jsonify({"error": f"Permission denied: {path}"}), 403
+        except OSError as exc:
+            return jsonify({"error": str(exc)}), 400
+        for entry in entries:
+            if entry.name.startswith("."):
+                continue
+            try:
+                if entry.is_dir():
+                    dirs.append({"name": entry.name, "path": str(entry)})
+                elif (
+                    entry.is_file()
+                    and entry.suffix.lower() in VIDEO_EXTENSIONS
+                ):
+                    video_count += 1
+            except OSError:
+                continue
+
+        parent = str(path.parent) if path.parent != path else None
+        return jsonify(
+            {
+                "path": str(path),
+                "parent": parent,
+                "dirs": dirs,
+                "video_count": video_count,
+                "home": str(Path.home()),
+            }
+        )
+
+    @app.route("/api/dubsync/scan")
+    def api_dubsync_scan():
+        """Parse a local folder's video filenames into season/episode keys."""
+        from ..models.aniworld_to.dubsync.matcher import scan_directory
+
+        from pathlib import Path
+
+        raw = request.args.get("path", "").strip()
+        if not raw:
+            return jsonify({"error": "path is required"}), 400
+        path = os.path.expanduser(raw)
+        recursive = request.args.get("recursive") == "1"
+        try:
+            parsed, unmatched = scan_directory(path, recursive=recursive)
+        except NotADirectoryError:
+            return jsonify({"error": f"Not a directory: {raw}"}), 400
+        except PermissionError:
+            return jsonify({"error": f"Permission denied: {raw}"}), 403
+        except OSError as exc:
+            return jsonify({"error": str(exc)}), 400
+
+        base = Path(path)
+
+        def _rel(p):
+            try:
+                return str(p.relative_to(base))
+            except ValueError:
+                return p.name
+
+        return jsonify(
+            {
+                "path": path,
+                "files": [
+                    {
+                        "name": pf.path.name,
+                        "rel": _rel(pf.path),
+                        "season": pf.season,
+                        "episode": pf.episode,
+                    }
+                    for pf in parsed
+                ],
+                "unparsed": [{"name": p.name, "rel": _rel(p)} for p in unmatched],
+            }
+        )
 
     @app.route("/api/popular-movies")
     def api_popular_movies():
@@ -2269,6 +2693,15 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                 "available_ui_languages": list(SUPPORTED_UI_LANGUAGES),
                 "available_output_formats": list(SUPPORTED_OUTPUT_FORMATS),
                 "discord": _discord_settings(),
+                "dubsync": {
+                    "target_dir": os.environ.get("ANIWORLD_DUBSYNC_TARGET_DIR", ""),
+                    "offset": os.environ.get("ANIWORLD_DUBSYNC_OFFSET", ""),
+                    "auto_align": os.environ.get("ANIWORLD_DUBSYNC_AUTO_ALIGN", "1"),
+                    "allow_resample": os.environ.get(
+                        "ANIWORLD_DUBSYNC_ALLOW_RESAMPLE", "0"
+                    ),
+                    "cleanup": os.environ.get("ANIWORLD_DUBSYNC_CLEANUP", "0"),
+                },
             }
         )
 
@@ -2376,6 +2809,35 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             error = _apply_discord_settings(data["discord"], env_updates)
             if error:
                 return jsonify({"error": error}), 400
+
+        if "dubsync" in data:
+            ds = data["dubsync"] or {}
+            if "target_dir" in ds:
+                env_updates["ANIWORLD_DUBSYNC_TARGET_DIR"] = str(
+                    ds["target_dir"]
+                ).strip()
+            if "offset" in ds:
+                raw_offset = str(ds["offset"]).strip()
+                if raw_offset:
+                    try:
+                        float(raw_offset)
+                    except ValueError:
+                        return jsonify(
+                            {"error": f"Invalid dubsync offset: {raw_offset}"}
+                        ), 400
+                env_updates["ANIWORLD_DUBSYNC_OFFSET"] = raw_offset
+            if "auto_align" in ds:
+                env_updates["ANIWORLD_DUBSYNC_AUTO_ALIGN"] = (
+                    "1" if ds["auto_align"] else "0"
+                )
+            if "allow_resample" in ds:
+                env_updates["ANIWORLD_DUBSYNC_ALLOW_RESAMPLE"] = (
+                    "1" if ds["allow_resample"] else "0"
+                )
+            if "cleanup" in ds:
+                env_updates["ANIWORLD_DUBSYNC_CLEANUP"] = (
+                    "1" if ds["cleanup"] else "0"
+                )
 
         # Settings are intentionally in-memory only for the running process.
         # To persist across restarts, users set them in their .env file.
@@ -2505,6 +2967,12 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
     @app.route("/autosync")
     def autosync_page():
         return render_template("autosync.html")
+
+    # ===== DubSync Page =====
+
+    @app.route("/dubsync")
+    def dubsync_page():
+        return render_template("dubsync.html")
 
     # ===== Auto-Sync API =====
 
@@ -2897,6 +3365,12 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
         # Endpoints that require admin instead of just login
         _admin_only = {
             "settings_page",
+            # DubSync browses the server's filesystem and writes into local
+            # folders, so the whole feature is admin-only under auth.
+            "dubsync_page",
+            "api_dubsync",
+            "api_dubsync_browse",
+            "api_dubsync_scan",
             "api_settings",
             "api_settings_public_ip",
             "api_settings_update",

--- a/src/aniworld/web/db.py
+++ b/src/aniworld/web/db.py
@@ -330,6 +330,11 @@ def init_queue_db():
             conn.execute("ALTER TABLE download_queue ADD COLUMN discord_user_id TEXT")
         except Exception:
             pass  # column already exists
+        try:
+            # Per-job feature options (JSON): extra_languages, fetch_subs, ...
+            conn.execute("ALTER TABLE download_queue ADD COLUMN options TEXT")
+        except Exception:
+            pass  # column already exists
         conn.commit()
     finally:
         conn.close()
@@ -345,14 +350,15 @@ def add_to_queue(
     custom_path_id=None,
     source="manual",
     discord_user_id=None,
+    options=None,
 ):
     import json
 
     conn = get_db()
     try:
         cur = conn.execute(
-            "INSERT INTO download_queue (title, series_url, episodes, total_episodes, language, provider, username, custom_path_id, source, discord_user_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO download_queue (title, series_url, episodes, total_episodes, language, provider, username, custom_path_id, source, discord_user_id, options) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 title,
                 series_url,
@@ -364,6 +370,7 @@ def add_to_queue(
                 custom_path_id,
                 source,
                 discord_user_id,
+                json.dumps(options) if options else None,
             ),
         )
         row_id = cur.lastrowid

--- a/src/aniworld/web/static/app.js
+++ b/src/aniworld/web/static/app.js
@@ -539,6 +539,7 @@ function rebuildLanguageSelect() {
   } else if (validValues.length) {
     languageSelect.value = validValues[0];
   }
+  refreshDownloadOptions();
 }
 
 // Restore site state from localStorage
@@ -563,7 +564,76 @@ searchInput.addEventListener("input", () => {
     showBrowseSections();
   }
 });
-languageSelect.addEventListener("change", updateProviderDropdown);
+languageSelect.addEventListener("change", () => {
+  updateProviderDropdown();
+  refreshDownloadOptions();
+});
+
+// ---- Per-download feature options (extra languages, real subtitles) ----
+
+function refreshDownloadOptions() {
+  const extraRow = document.getElementById("extraLangsRow");
+  const checksSpan = document.getElementById("extraLangChecks");
+  const subsRow = document.getElementById("fetchSubsRow");
+  if (!extraRow || !checksSpan || !subsRow) return;
+
+  // Real subtitle tracks come from the anime fansub scene -> AniWorld only.
+  subsRow.style.display = currentSite === "aniworld" ? "" : "none";
+
+  // Extra audio languages only work where the downloader can merge tracks.
+  const mergeSites = ["aniworld", "sto"];
+  const selected = languageSelect.value;
+  const visibleOthers = Array.from(languageSelect.options).filter(
+    (opt) =>
+      !opt.hidden && opt.value !== selected && opt.value !== "All Languages",
+  );
+  if (
+    !mergeSites.includes(currentSite) ||
+    selected === "All Languages" ||
+    !visibleOthers.length
+  ) {
+    extraRow.style.display = "none";
+    checksSpan.innerHTML = "";
+    return;
+  }
+
+  const previouslyChecked = new Set(
+    Array.from(checksSpan.querySelectorAll("input:checked")).map(
+      (c) => c.value,
+    ),
+  );
+  checksSpan.innerHTML = "";
+  visibleOthers.forEach((opt) => {
+    const label = document.createElement("label");
+    label.className = "dl-opt-check";
+    const box = document.createElement("input");
+    box.type = "checkbox";
+    box.value = opt.value;
+    box.checked = previouslyChecked.has(opt.value);
+    label.appendChild(box);
+    label.appendChild(document.createTextNode(" " + opt.value));
+    checksSpan.appendChild(label);
+  });
+  extraRow.style.display = "";
+}
+
+function selectedDownloadOptions() {
+  const body = {};
+  const checksSpan = document.getElementById("extraLangChecks");
+  const extraRow = document.getElementById("extraLangsRow");
+  if (checksSpan && extraRow && extraRow.style.display !== "none") {
+    const extras = Array.from(
+      checksSpan.querySelectorAll("input:checked"),
+    ).map((c) => c.value);
+    if (extras.length) body.extra_languages = extras;
+  }
+  const subsRow = document.getElementById("fetchSubsRow");
+  const subsCheck = document.getElementById("fetchSubsCheck");
+  if (subsRow && subsCheck && subsRow.style.display !== "none" && subsCheck.checked) {
+    body.fetch_subs = "ger";
+  }
+  return body;
+}
 
 function renderBrowseCards(grid, items) {
   grid.innerHTML = "";
@@ -741,6 +811,9 @@ async function openSeries(url) {
   const controlsDiv = document.querySelector(".controls");
   if (controlsDiv) controlsDiv.style.display = isHtvSeries || isMangaFireSeries ? "none" : "";
   if (mangaFireControls) mangaFireControls.style.display = isMangaFireSeries ? "flex" : "none";
+  const dlOptionsDiv = document.getElementById("dlOptions");
+  if (dlOptionsDiv)
+    dlOptionsDiv.style.display = isHtvSeries || isMangaFireSeries ? "none" : "";
   await checkLangSeparation();
   if (downloadAllLangsBtn && isMangaFireSeries) {
     downloadAllLangsBtn.style.display = "none";
@@ -1105,6 +1178,7 @@ function filterLanguageSelectToAvailable() {
   if (!stillValid && visibleOptions.length) {
     languageSelect.value = visibleOptions[0].value;
   }
+  refreshDownloadOptions();
 }
 
 function resetProviderDropdown() {
@@ -1200,6 +1274,9 @@ async function startDownload(all) {
       if (formatSelect) {
         dlBody.mangafire_format = formatSelect.value;
       }
+    }
+    if (!isHtvDl && !isMangaFireDl) {
+      Object.assign(dlBody, selectedDownloadOptions());
     }
     if (customPathSelect && customPathSelect.value) {
       dlBody.custom_path_id = parseInt(customPathSelect.value);

--- a/src/aniworld/web/static/dubsync.js
+++ b/src/aniworld/web/static/dubsync.js
@@ -1,0 +1,883 @@
+// DubSync page: pick a local folder, search the show, auto-select the
+// episodes whose files exist locally, queue the graft job.
+
+let dsScan = null; // {files: [{name, rel, season, episode}], unparsed: [{name, rel}]}
+let dsShow = null; // {url, title, poster_url}
+let dsSeasons = []; // [{url, season_number, episode_count, are_movies}]
+let dsEpisodes = {}; // season_number -> [{episode_number, url, title_de, title_en, available_languages}]
+let dsPairs = {}; // "s:e" -> local filename (auto-match result)
+let dsBrowserCurrent = null; // path shown in the browser modal
+
+function showToast(msg) {
+  const toast = document.getElementById("toast");
+  if (!toast) return;
+  toast.textContent = msg;
+  toast.classList.add("show");
+  setTimeout(() => toast.classList.remove("show"), 3200);
+}
+
+function dsT(key, fallback) {
+  return typeof window.t === "function" ? window.t(key, fallback) : fallback;
+}
+
+// ===== Init =====
+
+async function dsInit() {
+  let defaults = {};
+  try {
+    const resp = await fetch("/api/settings");
+    const data = await resp.json();
+    defaults = data.dubsync || {};
+  } catch (e) {
+    /* settings are optional prefill only */
+  }
+
+  document.getElementById("dsOffset").value = defaults.offset || "";
+  document.getElementById("dsAutoAlign").checked = defaults.auto_align !== "0";
+  document.getElementById("dsAllowResample").checked =
+    defaults.allow_resample === "1";
+  document.getElementById("dsCleanup").checked = defaults.cleanup === "1";
+
+  const folder =
+    localStorage.getItem("dubsyncFolder") || defaults.target_dir || "";
+  if (folder) {
+    document.getElementById("dsFolder").value = folder;
+    dsRescan();
+  }
+  dsUpdateSummary();
+}
+
+// ===== Step 1: folder + scan =====
+
+function dsFolderChanged() {
+  const folder = document.getElementById("dsFolder").value.trim();
+  if (folder) localStorage.setItem("dubsyncFolder", folder);
+  dsRescan();
+}
+
+async function dsRescan() {
+  const folder = document.getElementById("dsFolder").value.trim();
+  const info = document.getElementById("dsScanInfo");
+  const filesBox = document.getElementById("dsScanFiles");
+  dsScan = null;
+  filesBox.textContent = "";
+  if (!folder) {
+    info.textContent = "";
+    if (dsSeasons.length) dsRenderEpisodes();
+    dsApplyAutoSelection();
+    return;
+  }
+
+  info.textContent = dsT("dubsync.scanning", "Scanning folder…");
+  const recursive = document.getElementById("dsRecursive").checked ? "1" : "0";
+  try {
+    const resp = await fetch(
+      "/api/dubsync/scan?path=" +
+        encodeURIComponent(folder) +
+        "&recursive=" +
+        recursive
+    );
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || resp.statusText);
+    dsScan = data;
+  } catch (e) {
+    info.textContent = dsT("dubsync.scan_failed", "Scan failed: ") + e.message;
+    if (dsSeasons.length) dsRenderEpisodes();
+    dsApplyAutoSelection();
+    return;
+  }
+
+  // Neutral summary: a folder full of movies legitimately has no episode
+  // numbers, so lead with the total and only break down parsing when useful.
+  const nParsed = dsScan.files.length;
+  const nUnparsed = dsScan.unparsed.length;
+  const total = nParsed + nUnparsed;
+  let text =
+    total +
+    " " +
+    (total === 1
+      ? dsT("dubsync.scan_found_one", "video file found")
+      : dsT("dubsync.scan_found_many", "video files found"));
+  if (nParsed && nUnparsed) {
+    text +=
+      " (" +
+      nParsed +
+      " " +
+      dsT("dubsync.scan_with_ep", "with episode numbers") +
+      ", " +
+      nUnparsed +
+      " " +
+      dsT("dubsync.scan_without_ep", "without") +
+      ")";
+  } else if (!nParsed && nUnparsed) {
+    text +=
+      " (" +
+      dsT(
+        "dubsync.scan_movies_ok",
+        "no episode numbers in the filenames — fine for movies"
+      ) +
+      ")";
+  }
+  info.textContent = text;
+
+  // Movie dropdowns list every video file; rebuild them for the new scan.
+  if (dsSeasons.length) dsRenderEpisodes();
+
+  // Compact chip list: "S1E01 · file.mkv" for parsed files, "🎬 file.mkv"
+  // for files without an episode number (typically movies).
+  const chips = dsScan.files
+    .map((f) => {
+      const season = f.season === null ? "?" : f.season;
+      return (
+        "S" + season + "E" + String(f.episode).padStart(2, "0") + " · " + f.name
+      );
+    })
+    .concat(dsScan.unparsed.map((u) => "🎬 " + u.name));
+  for (const label of chips.slice(0, 60)) {
+    const chip = document.createElement("span");
+    chip.style.cssText =
+      "display:inline-block;margin:2px 6px 2px 0;padding:2px 8px;" +
+      "border-radius:8px;background:rgba(37,99,235,0.12);color:#9db8e8;" +
+      "font-size:0.75rem;";
+    chip.textContent = label;
+    filesBox.appendChild(chip);
+  }
+  if (chips.length > 60) {
+    const more = document.createElement("span");
+    more.className = "settings-hint";
+    more.textContent = "+" + (chips.length - 60) + " …";
+    filesBox.appendChild(more);
+  }
+
+  dsApplyAutoSelection();
+}
+
+// ===== Folder browser modal =====
+
+async function dsBrowse(path) {
+  const list = document.getElementById("dsBrowserList");
+  list.textContent = "";
+  try {
+    const resp = await fetch(
+      "/api/dubsync/browse" +
+        (path ? "?path=" + encodeURIComponent(path) : "")
+    );
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || resp.statusText);
+
+    dsBrowserCurrent = data.path;
+    document.getElementById("dsBrowserPath").textContent = data.path;
+    const upBtn = document.getElementById("dsBrowserUp");
+    upBtn.disabled = !data.parent;
+    upBtn.dataset.parent = data.parent || "";
+
+    const videos = document.getElementById("dsBrowserVideos");
+    videos.textContent = data.video_count
+      ? data.video_count +
+        " " +
+        dsT("dubsync.browser_videos", "video file(s) in this folder")
+      : "";
+
+    if (!data.dirs.length) {
+      const empty = document.createElement("div");
+      empty.className = "settings-hint";
+      empty.style.cssText = "padding: 12px";
+      empty.textContent = dsT("dubsync.browser_empty", "No subfolders");
+      list.appendChild(empty);
+    }
+    for (const dir of data.dirs) {
+      const row = document.createElement("div");
+      row.style.cssText =
+        "padding:9px 14px;cursor:pointer;color:#c8cad0;font-size:0.88rem;" +
+        "border-bottom:1px solid rgba(255,255,255,0.05);";
+      row.textContent = "📁 " + dir.name;
+      row.onmouseenter = () =>
+        (row.style.background = "rgba(255,255,255,0.05)");
+      row.onmouseleave = () => (row.style.background = "");
+      row.onclick = () => dsBrowse(dir.path);
+      list.appendChild(row);
+    }
+  } catch (e) {
+    const err = document.createElement("div");
+    err.className = "settings-hint";
+    err.style.cssText = "padding: 12px";
+    err.textContent = e.message;
+    list.appendChild(err);
+  }
+}
+
+function dsOpenBrowser() {
+  document.getElementById("dsBrowserOverlay").style.display = "block";
+  dsBrowse(document.getElementById("dsFolder").value.trim() || null);
+}
+
+function dsCloseBrowser() {
+  document.getElementById("dsBrowserOverlay").style.display = "none";
+}
+
+function dsBrowserUp() {
+  const parent = document.getElementById("dsBrowserUp").dataset.parent;
+  if (parent) dsBrowse(parent);
+}
+
+function dsBrowserSelect() {
+  if (!dsBrowserCurrent) return;
+  document.getElementById("dsFolder").value = dsBrowserCurrent;
+  dsCloseBrowser();
+  dsFolderChanged();
+}
+
+// ===== Step 2: show search =====
+
+async function dsSearchShows() {
+  const keyword = document.getElementById("dsSearch").value.trim();
+  const site = document.getElementById("dsSite").value;
+  const box = document.getElementById("dsResults");
+  if (!keyword) return;
+
+  box.textContent = dsT("dubsync.searching", "Searching…");
+  try {
+    const resp = await fetch("/api/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ keyword, site }),
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || resp.statusText);
+
+    box.textContent = "";
+    if (!data.results.length) {
+      box.className = "settings-hint";
+      box.textContent = dsT("dubsync.no_results", "No results");
+      return;
+    }
+    box.className = "";
+    for (const item of data.results.slice(0, 12)) {
+      const row = document.createElement("div");
+      row.style.cssText =
+        "padding:9px 14px;cursor:pointer;color:#c8cad0;font-size:0.9rem;" +
+        "border:1px solid rgba(255,255,255,0.07);border-radius:10px;" +
+        "margin-bottom:6px;";
+      row.textContent = item.title;
+      row.onmouseenter = () =>
+        (row.style.background = "rgba(255,255,255,0.05)");
+      row.onmouseleave = () => (row.style.background = "");
+      row.onclick = () => dsSelectShow(item);
+      box.appendChild(row);
+    }
+  } catch (e) {
+    box.className = "settings-hint";
+    box.textContent = dsT("dubsync.search_failed", "Search failed: ") + e.message;
+  }
+}
+
+async function dsSelectShow(item) {
+  dsShow = { url: item.url, title: item.title, poster_url: "" };
+  dsSeasons = [];
+  dsEpisodes = {};
+  dsPairs = {};
+
+  document.getElementById("dsResults").textContent = "";
+  const header = document.getElementById("dsShowHeader");
+  header.style.display = "flex";
+  header.style.cssText +=
+    ";align-items:center;gap:14px;";
+  header.textContent = "";
+
+  const img = document.createElement("img");
+  img.style.cssText =
+    "width:52px;height:74px;object-fit:cover;border-radius:8px;display:none;";
+  header.appendChild(img);
+
+  const meta = document.createElement("div");
+  const title = document.createElement("div");
+  title.style.cssText = "color:#fff;font-weight:600;";
+  title.textContent = item.title;
+  meta.appendChild(title);
+  const state = document.createElement("div");
+  state.className = "settings-hint";
+  state.style.margin = "4px 0 0";
+  state.textContent = dsT("dubsync.loading_seasons", "Loading episode list…");
+  meta.appendChild(state);
+  header.appendChild(meta);
+
+  const change = document.createElement("button");
+  change.textContent = dsT("dubsync.change_show", "Change");
+  change.style.cssText =
+    "margin-left:auto;padding:8px 16px;border-radius:10px;cursor:pointer;" +
+    "border:1px solid rgba(255,255,255,0.1);background:rgba(255,255,255,0.04);" +
+    "color:#c8cad0;font-size:0.82rem;";
+  change.onclick = () => {
+    dsShow = null;
+    dsSeasons = [];
+    dsEpisodes = {};
+    dsPairs = {};
+    header.style.display = "none";
+    document.getElementById("dsEpisodesSection").style.display = "none";
+    dsUpdateSummary();
+  };
+  header.appendChild(change);
+
+  try {
+    const [seriesResp, seasonsResp] = await Promise.all([
+      fetch("/api/series?url=" + encodeURIComponent(item.url)),
+      fetch("/api/seasons?url=" + encodeURIComponent(item.url)),
+    ]);
+    const series = await seriesResp.json();
+    const seasonsData = await seasonsResp.json();
+    if (!seasonsResp.ok)
+      throw new Error(seasonsData.error || seasonsResp.statusText);
+
+    if (seriesResp.ok && series.poster_url) {
+      img.src = series.poster_url;
+      img.style.display = "block";
+    }
+    dsSeasons = (seasonsData.seasons || []).filter(
+      (s) => s.season_number !== null && s.season_number !== undefined
+    );
+
+    const episodeResults = await Promise.all(
+      dsSeasons.map((s) =>
+        fetch("/api/episodes?url=" + encodeURIComponent(s.url))
+          .then((r) => r.json())
+          .catch(() => ({ episodes: [] }))
+      )
+    );
+    dsSeasons.forEach((s, i) => {
+      dsEpisodes[s.season_number] = episodeResults[i].episodes || [];
+    });
+
+    if (dsSeasons.length && dsSeasons.every((s) => s.are_movies)) {
+      state.textContent = dsT("dubsync.movie_source", "Movie");
+    } else {
+      state.textContent =
+        dsSeasons.length +
+        " " +
+        (dsSeasons.length === 1
+          ? dsT("dubsync.season_one", "season")
+          : dsT("dubsync.season_many", "seasons"));
+    }
+    dsRenderEpisodes();
+    dsApplyAutoSelection();
+  } catch (e) {
+    state.textContent =
+      dsT("dubsync.load_failed", "Failed to load episodes: ") + e.message;
+  }
+}
+
+// ===== Step 3: episode checklist =====
+
+function dsRenderEpisodes() {
+  const section = document.getElementById("dsEpisodesSection");
+  const box = document.getElementById("dsSeasons");
+  box.textContent = "";
+  section.style.display = "block";
+
+  for (const season of dsSeasons) {
+    const sn = season.season_number;
+    const episodes = dsEpisodes[sn] || [];
+    const block = document.createElement("div");
+    block.style.cssText = "margin-bottom: 16px";
+
+    const head = document.createElement("label");
+    head.style.cssText =
+      "display:flex;align-items:center;gap:8px;color:#fff;font-weight:600;" +
+      "font-size:0.92rem;cursor:pointer;margin-bottom:8px;";
+    const all = document.createElement("input");
+    all.type = "checkbox";
+    all.style.cssText = "accent-color:#2563eb;cursor:pointer;";
+    all.dataset.season = sn;
+    all.onchange = () => {
+      block.querySelectorAll("input[data-ep]").forEach((cb) => {
+        // movie checkboxes stay disabled until a local file is chosen
+        if (!cb.disabled) cb.checked = all.checked;
+      });
+      dsUpdateSummary();
+    };
+    head.appendChild(all);
+    head.appendChild(
+      document.createTextNode(
+        season.are_movies
+          ? dsT("dubsync.movies", "Movies")
+          : dsT("dubsync.season_label", "Season") + " " + sn
+      )
+    );
+    block.appendChild(head);
+
+    if (season.are_movies) {
+      // Movies carry no episode pattern in their filenames, so each one
+      // gets an explicit local-file dropdown instead of automatic matching.
+      const hint = document.createElement("div");
+      hint.className = "settings-hint";
+      hint.style.cssText = "margin:-2px 0 8px;";
+      hint.textContent = dsT(
+        "dubsync.movies_hint",
+        "Pick the local file for each movie; the best title match is pre-selected."
+      );
+      block.appendChild(hint);
+
+      const fileRels = dsAllFileRels();
+      for (const ep of episodes) {
+        const row = document.createElement("div");
+        row.style.cssText =
+          "display:flex;align-items:center;gap:10px;color:#c8cad0;" +
+          "font-size:0.85rem;margin-bottom:6px;flex-wrap:wrap;";
+        const cb = document.createElement("input");
+        cb.type = "checkbox";
+        cb.style.cssText = "accent-color:#2563eb;cursor:pointer;flex-shrink:0;";
+        cb.dataset.ep = ep.episode_number;
+        cb.dataset.season = sn;
+        cb.dataset.movie = "1";
+        cb.disabled = true;
+        cb.title = dsT("dubsync.movie_need_file", "Choose a local file first");
+        cb.onchange = dsUpdateSummary;
+        row.appendChild(cb);
+
+        const label = document.createElement("span");
+        label.style.cssText =
+          "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" +
+          "flex:1 1 180px;min-width:0;";
+        const epTitle = ep.title_de || ep.title_en || "";
+        label.textContent =
+          epTitle || dsT("dubsync.movie_n", "Movie") + " " + ep.episode_number;
+        row.appendChild(label);
+
+        const langs = ep.available_languages || [];
+        if (langs.length && !langs.includes("German Dub")) {
+          const warn = document.createElement("span");
+          warn.title = dsT("dubsync.no_dub", "No German Dub available");
+          warn.textContent = "⚠";
+          warn.style.cssText = "color:#eab308;flex-shrink:0;";
+          row.appendChild(warn);
+        }
+
+        const sel = document.createElement("select");
+        sel.className = "sync-select";
+        sel.style.cssText = "flex:0 1 320px;min-width:180px;font-size:0.82rem;";
+        sel.dataset.movieSel = sn + ":" + ep.episode_number;
+        const none = document.createElement("option");
+        none.value = "";
+        none.textContent = dsT("dubsync.movie_no_file", "— choose local file —");
+        sel.appendChild(none);
+        for (const rel of fileRels) {
+          const opt = document.createElement("option");
+          opt.value = rel;
+          opt.textContent = rel;
+          sel.appendChild(opt);
+        }
+        sel.onchange = () => {
+          cb.disabled = !sel.value;
+          cb.checked = !!sel.value;
+          dsUpdateSummary();
+        };
+        row.appendChild(sel);
+
+        block.appendChild(row);
+      }
+      box.appendChild(block);
+      continue;
+    }
+
+    const grid = document.createElement("div");
+    grid.style.cssText =
+      "display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));" +
+      "gap:4px 16px;";
+    for (const ep of episodes) {
+      const row = document.createElement("label");
+      row.style.cssText =
+        "display:flex;align-items:center;gap:8px;color:#c8cad0;" +
+        "font-size:0.85rem;cursor:pointer;min-width:0;";
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.style.cssText = "accent-color:#2563eb;cursor:pointer;flex-shrink:0;";
+      cb.dataset.ep = ep.episode_number;
+      cb.dataset.season = sn;
+      cb.onchange = dsUpdateSummary;
+      row.appendChild(cb);
+
+      const label = document.createElement("span");
+      label.style.cssText =
+        "overflow:hidden;text-overflow:ellipsis;white-space:nowrap;";
+      const epTitle = ep.title_de || ep.title_en || "";
+      label.textContent =
+        "E" + String(ep.episode_number).padStart(2, "0") +
+        (epTitle ? " · " + epTitle : "");
+      row.appendChild(label);
+
+      const langs = ep.available_languages || [];
+      if (langs.length && !langs.includes("German Dub")) {
+        const warn = document.createElement("span");
+        warn.title = dsT("dubsync.no_dub", "No German Dub available");
+        warn.textContent = "⚠";
+        warn.style.cssText = "color:#eab308;flex-shrink:0;";
+        row.appendChild(warn);
+      }
+
+      const marker = document.createElement("span");
+      marker.dataset.pairMarker = sn + ":" + ep.episode_number;
+      marker.style.cssText =
+        "display:none;color:#4ade80;font-size:0.75rem;flex-shrink:0;";
+      marker.textContent = "●";
+      row.appendChild(marker);
+
+      grid.appendChild(row);
+    }
+    block.appendChild(grid);
+    box.appendChild(block);
+  }
+}
+
+// Every scanned video file (parsed or not) as a path relative to the folder,
+// for the movie pairing dropdowns.
+function dsAllFileRels() {
+  if (!dsScan) return [];
+  const rels = dsScan.files
+    .map((f) => f.rel || f.name)
+    .concat(dsScan.unparsed.map((u) => u.rel || u.name));
+  return [...new Set(rels)].sort();
+}
+
+// ===== Movie title matching (fuzzy filename <-> title guess) =====
+
+const DS_NOISE_TOKENS = new Set([
+  "1080p", "720p", "2160p", "480p", "bluray", "blu", "ray", "bdrip", "brrip",
+  "web", "webrip", "webdl", "dl", "hdtv", "x264", "x265", "h264", "h265",
+  "hevc", "avc", "aac", "ac3", "eac3", "dts", "flac", "opus", "german",
+  "deutsch", "english", "ger", "eng", "japanese", "jap", "dub", "sub",
+  "subbed", "dubbed", "dual", "multi", "remux", "hdr", "uhd", "sdr",
+  "the", "der", "die", "das", "film", "movie",
+]);
+
+function dsNormTokens(s) {
+  let text = String(s || "").toLowerCase();
+  text = text.replace(/\.[a-z0-9]{2,4}$/, ""); // extension
+  text = text.replace(/\[[^\]]*\]|\([^)]*\)/g, " "); // release groups, years
+  text = text.replace(/[^a-z0-9äöüß]+/g, " ");
+  return text
+    .split(/\s+/)
+    .filter(
+      (t) => t && !DS_NOISE_TOKENS.has(t) && !/^(19|20)\d\d$/.test(t)
+    );
+}
+
+// Dice coefficient over token sets: 0 (nothing shared) .. 1 (same tokens).
+function dsTitleScore(a, b) {
+  const ta = new Set(dsNormTokens(a));
+  const tb = new Set(dsNormTokens(b));
+  if (!ta.size || !tb.size) return 0;
+  let inter = 0;
+  ta.forEach((t) => {
+    if (tb.has(t)) inter++;
+  });
+  return (2 * inter) / (ta.size + tb.size);
+}
+
+// Mirror of the backend matcher's season resolution: filename season if
+// present, else the source's single season, else 1 — plus the
+// absolute-numbering fallback for globally-unique episode numbers.
+function dsApplyAutoSelection() {
+  const warnings = document.getElementById("dsMatchWarnings");
+  warnings.textContent = "";
+  dsPairs = {};
+
+  document
+    .querySelectorAll("#dsSeasons [data-pair-marker]")
+    .forEach((m) => (m.style.display = "none"));
+
+  if (!dsSeasons.length) {
+    dsUpdateSummary();
+    return;
+  }
+
+  // Movie collections pair via the explicit dropdowns below, never via
+  // filename episode numbers.
+  const epSeasons = dsSeasons.filter((s) => !s.are_movies);
+
+  const byKey = new Set();
+  const absCount = {};
+  for (const season of epSeasons) {
+    for (const ep of dsEpisodes[season.season_number] || []) {
+      byKey.add(season.season_number + ":" + ep.episode_number);
+      absCount[ep.episode_number] = (absCount[ep.episode_number] || []).concat(
+        season.season_number
+      );
+    }
+  }
+  const singleSeason =
+    epSeasons.length === 1 ? epSeasons[0].season_number : null;
+
+  document
+    .querySelectorAll("#dsSeasons input[data-ep]:not([data-movie])")
+    .forEach((cb) => (cb.checked = false));
+
+  const unpaired = [];
+  for (const f of (dsScan && dsScan.files) || []) {
+    let season = f.season !== null ? f.season : singleSeason !== null ? singleSeason : 1;
+    let key = season + ":" + f.episode;
+    if (!byKey.has(key) && f.season === null) {
+      const seasonsWithEp = absCount[f.episode] || [];
+      if (seasonsWithEp.length === 1) {
+        key = seasonsWithEp[0] + ":" + f.episode;
+      }
+    }
+    if (byKey.has(key) && !(key in dsPairs)) {
+      dsPairs[key] = f.name;
+    } else if (!byKey.has(key)) {
+      unpaired.push(f);
+    }
+  }
+
+  for (const key of Object.keys(dsPairs)) {
+    const [s, e] = key.split(":");
+    const cb = document.querySelector(
+      '#dsSeasons input[data-season="' + s + '"][data-ep="' + e + '"]'
+    );
+    if (cb) cb.checked = true;
+    const marker = document.querySelector(
+      '#dsSeasons [data-pair-marker="' + key + '"]'
+    );
+    if (marker) {
+      marker.style.display = "inline";
+      marker.title =
+        dsT("dubsync.local_file", "Local file: ") + dsPairs[key];
+    }
+  }
+
+  // Movie auto-pairing: guess each movie's local file by title similarity.
+  const movieEntries = [];
+  for (const season of dsSeasons) {
+    if (!season.are_movies) continue;
+    for (const ep of dsEpisodes[season.season_number] || []) {
+      movieEntries.push({
+        key: season.season_number + ":" + ep.episode_number,
+        title: ep.title_de || ep.title_en || "",
+      });
+    }
+  }
+  const fileRels = dsAllFileRels();
+  const usedRels = new Set();
+  if (movieEntries.length === 1 && fileRels.length === 1) {
+    // one movie, one file: unambiguous
+    dsSetMoviePair(movieEntries[0].key, fileRels[0]);
+    usedRels.add(fileRels[0]);
+  } else {
+    for (const movie of movieEntries) {
+      let best = null;
+      let bestScore = 0;
+      for (const rel of fileRels) {
+        if (usedRels.has(rel)) continue;
+        const score = dsTitleScore(movie.title, rel);
+        if (score > bestScore) {
+          best = rel;
+          bestScore = score;
+        }
+      }
+      if (best && bestScore >= 0.35) {
+        dsSetMoviePair(movie.key, best);
+        usedRels.add(best);
+      }
+    }
+  }
+
+  const notes = [];
+  const unpairedLeft = unpaired.filter((f) => !usedRels.has(f.rel || f.name));
+  if (unpairedLeft.length) {
+    notes.push(
+      unpairedLeft.length +
+        " " +
+        dsT("dubsync.unpaired", "local file(s) have no matching episode: ") +
+        unpairedLeft
+          .slice(0, 5)
+          .map((f) => f.name)
+          .join(", ") +
+        (unpairedLeft.length > 5 ? ", …" : "")
+    );
+  }
+  // When the source has a Movies section, files without episode numbers are
+  // normal candidates for the movie dropdowns, not a problem to warn about.
+  const hasMovies = dsSeasons.some((s) => s.are_movies);
+  const unparsedLeft = hasMovies
+    ? []
+    : ((dsScan && dsScan.unparsed) || []).filter(
+        (u) => !usedRels.has(u.rel || u.name)
+      );
+  if (unparsedLeft.length) {
+    notes.push(
+      dsT("dubsync.unparsed_note", "Not recognised: ") +
+        unparsedLeft
+          .slice(0, 5)
+          .map((u) => u.name)
+          .join(", ") +
+        (unparsedLeft.length > 5 ? ", …" : "")
+    );
+  }
+  for (const note of notes) {
+    const div = document.createElement("div");
+    div.className = "settings-hint";
+    div.style.cssText = "color:#eab308;margin-top:4px;";
+    div.textContent = "⚠ " + note;
+    warnings.appendChild(div);
+  }
+
+  dsUpdateSummary();
+}
+
+// Reflect a movie's auto-guessed local file in its dropdown + checkbox.
+function dsSetMoviePair(key, rel) {
+  const sel = document.querySelector(
+    '#dsSeasons select[data-movie-sel="' + key + '"]'
+  );
+  if (!sel) return;
+  sel.value = rel;
+  const [s, e] = key.split(":");
+  const cb = document.querySelector(
+    '#dsSeasons input[data-movie][data-season="' + s + '"][data-ep="' + e + '"]'
+  );
+  if (cb) {
+    cb.disabled = false;
+    cb.checked = true;
+  }
+}
+
+function dsSelectedEpisodes() {
+  const selected = [];
+  document
+    .querySelectorAll("#dsSeasons input[data-ep]:not([data-movie])")
+    .forEach((cb) => {
+      if (cb.checked)
+        selected.push([
+          parseInt(cb.dataset.season, 10),
+          parseInt(cb.dataset.ep, 10),
+        ]);
+    });
+  return selected;
+}
+
+// Checked movies with a confirmed local file, as [season, episode, filename].
+function dsSelectedMovies() {
+  const selected = [];
+  document
+    .querySelectorAll("#dsSeasons input[data-ep][data-movie]")
+    .forEach((cb) => {
+      if (!cb.checked) return;
+      const key = cb.dataset.season + ":" + cb.dataset.ep;
+      const sel = document.querySelector(
+        '#dsSeasons select[data-movie-sel="' + key + '"]'
+      );
+      if (sel && sel.value)
+        selected.push([
+          parseInt(cb.dataset.season, 10),
+          parseInt(cb.dataset.ep, 10),
+          sel.value,
+        ]);
+    });
+  return selected;
+}
+
+function dsUpdateSummary() {
+  const nEp = dsSelectedEpisodes().length;
+  const nMov = dsSelectedMovies().length;
+  const folder = document.getElementById("dsFolder").value.trim();
+  const summary = document.getElementById("dsSummary");
+  const btn = document.getElementById("dsEnqueueBtn");
+
+  if (!dsShow || !folder) {
+    summary.textContent = dsT(
+      "dubsync.summary_incomplete",
+      "Pick a folder and a show first"
+    );
+    btn.disabled = true;
+    return;
+  }
+  const parts = [];
+  if (nEp || !nMov) {
+    parts.push(
+      nEp +
+        " " +
+        (nEp === 1
+          ? dsT("dubsync.summary_one", "episode selected")
+          : dsT("dubsync.summary_many", "episodes selected"))
+    );
+  }
+  if (nMov) {
+    parts.push(
+      nMov +
+        " " +
+        (nMov === 1
+          ? dsT("dubsync.summary_movie_one", "movie selected")
+          : dsT("dubsync.summary_movie_many", "movies selected"))
+    );
+  }
+  summary.textContent = parts.join(", ");
+  btn.disabled = nEp + nMov === 0;
+}
+
+// ===== Enqueue =====
+
+async function dsEnqueue() {
+  const folder = document.getElementById("dsFolder").value.trim();
+  const episodes = dsSelectedEpisodes();
+  const pairs = dsSelectedMovies();
+  if (!dsShow || !folder || (!episodes.length && !pairs.length)) return;
+
+  const btn = document.getElementById("dsEnqueueBtn");
+  btn.disabled = true;
+  try {
+    const resp = await fetch("/api/dubsync", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        url: dsShow.url,
+        target_dir: folder,
+        offset: document.getElementById("dsOffset").value.trim(),
+        auto_align: document.getElementById("dsAutoAlign").checked,
+        allow_resample: document.getElementById("dsAllowResample").checked,
+        cleanup: document.getElementById("dsCleanup").checked,
+        recursive: document.getElementById("dsRecursive").checked,
+        episodes: episodes,
+        pairs: pairs,
+      }),
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error || resp.statusText);
+    showToast("✓ " + dsT("dubsync.queued", "DubSync job added to queue"));
+    dsShowQueuedConfirmation();
+  } catch (e) {
+    showToast(dsT("dubsync.queue_failed", "Failed to enqueue: ") + e.message);
+    dsUpdateSummary();
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+// Inline confirmation next to the button: green check + a link that opens
+// the queue. Any later selection change redraws the summary over it.
+function dsShowQueuedConfirmation() {
+  const summary = document.getElementById("dsSummary");
+  summary.textContent = "";
+
+  const ok = document.createElement("span");
+  ok.style.cssText = "color:#4ade80;font-weight:600;";
+  ok.textContent = "✓ " + dsT("dubsync.queued", "DubSync job added to queue");
+  summary.appendChild(ok);
+
+  const link = document.createElement("a");
+  link.href = "#";
+  link.textContent = dsT("dubsync.view_queue", "View queue");
+  link.style.cssText = "margin-left:12px;color:#6ea8fe;";
+  link.onclick = (ev) => {
+    ev.preventDefault();
+    if (typeof openQueueModal === "function") openQueueModal();
+  };
+  summary.appendChild(link);
+
+  // brief visual feedback on the button itself
+  const btn = document.getElementById("dsEnqueueBtn");
+  const original = btn.textContent;
+  btn.textContent = "✓ " + dsT("dubsync.added", "Added");
+  setTimeout(() => {
+    btn.textContent = original;
+  }, 2000);
+}
+
+document.addEventListener("DOMContentLoaded", dsInit);

--- a/src/aniworld/web/static/i18n.js
+++ b/src/aniworld/web/static/i18n.js
@@ -15,6 +15,7 @@
       "nav.home": "Home",
       "nav.library": "Library",
       "nav.autosync": "Auto-Sync",
+      "nav.dubsync": "DubSync",
       "nav.planned": "Planned",
       "nav.queue": "Queue",
       "nav.settings": "Settings",
@@ -37,6 +38,12 @@
       "index.download_all": "Download All",
       "index.download_all_langs": "Download All Languages",
       "index.show_unofficial": "Show unofficial chapters",
+      "index.extra_langs": "Also download:",
+      "index.extra_langs_tip":
+        "Everything ends up in one file: each extra dub becomes another audio track you can switch to in your player, timed to match automatically. Sub versions have their subtitles burned into the picture, so they are added as a second video track you can switch to instead.",
+      "index.fetch_subs": "Add a real German subtitle track",
+      "index.fetch_subs_tip":
+        "Downloads the official German subtitles for this episode from the fansub scene and puts them into the file as subtitles you can turn on and off. Works for most anime from around 2020 onwards; if none are found the download simply completes without them.",
       "browse.new_movies": "New Movies",
       "browse.recent_series": "Recently Updated",
       "browse.trending_movies": "Trending Movies",
@@ -85,6 +92,105 @@
       "settings.ui_language": "Interface Language",
       "settings.ui_language_hint": "Language of this web interface.",
       "settings.interface": "Interface",
+      "settings.dubsync": "DubSync",
+      "settings.dubsync_hint":
+        "Defaults for the DubSync page (see the DubSync tab in the navigation). Each queued job can override them.",
+      "settings.dubsync_defaults": "Defaults",
+      "settings.dubsync_target_hint":
+        "Default local video folder, used to prefill the DubSync page.",
+      "settings.dubsync_offset": "Manual offset (seconds)",
+      "settings.dubsync_auto_align": "Automatic audio alignment",
+      "settings.dubsync_auto_align_hint":
+        "Detect each episode's dub offset by correlating the shared music/SFX bed. A manual offset always overrides detection.",
+      "settings.dubsync_allow_resample":
+        "Correct drift (re-encodes the dub track)",
+      "settings.dubsync_allow_resample_hint":
+        "Fixes PAL-speed dubs (~4% fast) via atempo. Only the added dub track is re-encoded; video and original audio stay untouched.",
+      "settings.dubsync_cleanup": "Edit files in place",
+      "settings.dubsync_cleanup_hint":
+        "When off, results are written as *.dubsync.mkv copies next to the originals (safe default).",
+      "settings.dubsync_saved": "DubSync defaults saved",
+      "dubsync.page_hint":
+        "Graft a German dub from AniWorld, SerienStream or a movie site losslessly onto your own archive-quality series and movie files as an additional audio track.",
+      "dubsync.step1": "1. Local folder",
+      "dubsync.step1_hint":
+        "Pick the folder that holds your local video files. Filenames are scanned for season/episode numbers; movie files don't need any.",
+      "dubsync.browse": "Browse…",
+      "dubsync.recursive": "Include subfolders",
+      "dubsync.scanning": "Scanning folder…",
+      "dubsync.scan_failed": "Scan failed: ",
+      "dubsync.scan_found_one": "video file found",
+      "dubsync.scan_found_many": "video files found",
+      "dubsync.scan_with_ep": "with episode numbers",
+      "dubsync.scan_without_ep": "without",
+      "dubsync.scan_movies_ok":
+        "no episode numbers in the filenames — fine for movies",
+      "dubsync.step2": "2. Show / Movie",
+      "dubsync.step2_hint":
+        "Search for the show or movie the dub should come from.",
+      "dubsync.search": "Search",
+      "dubsync.searching": "Searching…",
+      "dubsync.search_failed": "Search failed: ",
+      "dubsync.no_results": "No results",
+      "dubsync.loading_seasons": "Loading episode list…",
+      "dubsync.load_failed": "Failed to load episodes: ",
+      "dubsync.change_show": "Change",
+      "dubsync.season_one": "season",
+      "dubsync.season_many": "seasons",
+      "dubsync.step3": "3. Episodes & movies",
+      "dubsync.step3_hint":
+        "Episodes matching your local files are pre-selected. Movies have no episode numbers in their filenames, so each one gets a dropdown to confirm its local file. Adjust the selection before queueing.",
+      "dubsync.season_label": "Season",
+      "dubsync.movies": "Movies",
+      "dubsync.movies_hint":
+        "Pick the local file for each movie; the best title match is pre-selected.",
+      "dubsync.movie_source": "Movie",
+      "dubsync.movie_n": "Movie",
+      "dubsync.movie_no_file": "— choose local file —",
+      "dubsync.movie_need_file": "Choose a local file first",
+      "dubsync.no_dub": "No German Dub available",
+      "dubsync.local_file": "Local file: ",
+      "dubsync.unpaired": "local file(s) have no matching episode: ",
+      "dubsync.unparsed_note": "Not recognised: ",
+      "dubsync.step4": "4. Options",
+      "dubsync.step4_hint":
+        "The usual settings work for most jobs — you can just press Add to queue.",
+      "dubsync.offset": "Dub timing (seconds)",
+      "dubsync.offset_auto": "automatic",
+      "dubsync.offset_desc":
+        "Leave empty — the timing is worked out automatically.",
+      "dubsync.offset_tip":
+        "Only needed when the dub is consistently too early or too late in every episode. Example: -0.5 starts the dub half a second earlier. Entering a value here turns off the automatic timing above.",
+      "dubsync.auto_align": "Fix timing automatically (recommended)",
+      "dubsync.auto_align_desc":
+        "Lines the dub up with your video by comparing the two soundtracks.",
+      "dubsync.auto_align_tip":
+        "The dub comes from a stream that may start a little earlier or later than your file. DubSync listens for the music and sound effects both versions share and shifts the dub so it lines up. If it is not confident, it leaves the timing as-is and marks the job in the queue so you can check by ear.",
+      "dubsync.allow_resample": "Fix wrong playback speed",
+      "dubsync.allow_resample_desc":
+        "Some dubs run slightly too fast; this slows the dub down to match your video.",
+      "dubsync.allow_resample_tip":
+        "Dubs taken from TV broadcasts sometimes run about 4% too fast. Fixing that means the dub track is converted once — your video and its original audio are never touched. Only kicks in when a speed difference is actually found.",
+      "dubsync.cleanup": "Add the dub directly into my files",
+      "dubsync.cleanup_desc":
+        "When off, a new copy named *.dubsync.mkv is saved next to each file — the safe choice.",
+      "dubsync.cleanup_tip":
+        "Even with this on, your original is only replaced after the new version was written completely and successfully — a failed job never damages your files.",
+      "dubsync.add": "Add to queue",
+      "dubsync.added": "Added",
+      "dubsync.view_queue": "View queue",
+      "dubsync.summary_incomplete": "Pick a folder and a show first",
+      "dubsync.summary_one": "episode selected",
+      "dubsync.summary_many": "episodes selected",
+      "dubsync.summary_movie_one": "movie selected",
+      "dubsync.summary_movie_many": "movies selected",
+      "dubsync.queued": "DubSync job added to queue",
+      "dubsync.queue_failed": "Failed to enqueue: ",
+      "dubsync.browser_title": "Choose a folder",
+      "dubsync.browser_up": "← Back",
+      "dubsync.browser_select": "Use this folder",
+      "dubsync.browser_empty": "No subfolders",
+      "dubsync.browser_videos": "video file(s) in this folder",
       "settings.discord": "Discord Request Bot",
       "settings.discord.enable": "Enable Discord bot",
       "settings.discord.enable_hint":
@@ -129,6 +235,7 @@
       "nav.home": "Start",
       "nav.library": "Bibliothek",
       "nav.autosync": "Auto-Sync",
+      "nav.dubsync": "DubSync",
       "nav.planned": "Geplant",
       "nav.queue": "Warteschlange",
       "nav.settings": "Einstellungen",
@@ -151,6 +258,12 @@
       "index.download_all": "Alle herunterladen",
       "index.download_all_langs": "Alle Sprachen herunterladen",
       "index.show_unofficial": "Inoffizielle Kapitel anzeigen",
+      "index.extra_langs": "Zusätzlich laden:",
+      "index.extra_langs_tip":
+        "Alles landet in einer Datei: Jeder zusätzliche Dub wird eine weitere Tonspur, die sich im Player umschalten lässt – das Timing wird automatisch angepasst. Bei Sub-Versionen sind die Untertitel fest ins Bild eingebrannt, deshalb kommen sie als zweite, umschaltbare Videospur dazu.",
+      "index.fetch_subs": "Echte deutsche Untertitelspur hinzufügen",
+      "index.fetch_subs_tip":
+        "Lädt die offiziellen deutschen Untertitel der Episode aus der Fansub-Szene und fügt sie als ein- und ausschaltbare Untertitelspur in die Datei ein. Funktioniert für die meisten Anime ab ca. 2020; wird nichts gefunden, läuft der Download einfach ohne Untertitel durch.",
       "browse.new_movies": "Neue Filme",
       "browse.recent_series": "Zuletzt aktualisiert",
       "browse.trending_movies": "Angesagte Filme",
@@ -199,6 +312,105 @@
       "settings.ui_language": "Sprache der Oberfläche",
       "settings.ui_language_hint": "Sprache dieser Weboberfläche.",
       "settings.interface": "Oberfläche",
+      "settings.dubsync": "DubSync",
+      "settings.dubsync_hint":
+        "Standardwerte für die DubSync-Seite (siehe DubSync-Tab in der Navigation). Jeder Auftrag kann sie überschreiben.",
+      "settings.dubsync_defaults": "Standardwerte",
+      "settings.dubsync_target_hint":
+        "Standardordner der lokalen Videodateien; füllt die DubSync-Seite vor.",
+      "settings.dubsync_offset": "Manueller Versatz (Sekunden)",
+      "settings.dubsync_auto_align": "Automatische Tonspur-Ausrichtung",
+      "settings.dubsync_auto_align_hint":
+        "Erkennt den Versatz jeder Episode über die gemeinsame Musik-/Effektspur. Ein manueller Versatz hat immer Vorrang.",
+      "settings.dubsync_allow_resample":
+        "Drift korrigieren (kodiert die Dub-Spur neu)",
+      "settings.dubsync_allow_resample_hint":
+        "Behebt PAL-Geschwindigkeit (~4 % zu schnell) per atempo. Nur die neue Dub-Spur wird neu kodiert; Video und Originalton bleiben unberührt.",
+      "settings.dubsync_cleanup": "Dateien direkt bearbeiten",
+      "settings.dubsync_cleanup_hint":
+        "Wenn aus, werden Ergebnisse als *.dubsync.mkv-Kopien neben den Originalen gespeichert (sichere Voreinstellung).",
+      "settings.dubsync_saved": "DubSync-Standardwerte gespeichert",
+      "dubsync.page_hint":
+        "Fügt einen deutschen Dub von AniWorld, SerienStream oder einer Filmseite verlustfrei als zusätzliche Tonspur in deine eigenen hochwertigen Serien- und Filmdateien ein.",
+      "dubsync.step1": "1. Lokaler Ordner",
+      "dubsync.step1_hint":
+        "Wähle den Ordner mit deinen lokalen Videodateien. Die Dateinamen werden nach Staffel-/Episodennummern durchsucht; Filmdateien brauchen keine.",
+      "dubsync.browse": "Durchsuchen…",
+      "dubsync.recursive": "Unterordner einbeziehen",
+      "dubsync.scanning": "Ordner wird gescannt…",
+      "dubsync.scan_failed": "Scan fehlgeschlagen: ",
+      "dubsync.scan_found_one": "Videodatei gefunden",
+      "dubsync.scan_found_many": "Videodateien gefunden",
+      "dubsync.scan_with_ep": "mit Episodennummern",
+      "dubsync.scan_without_ep": "ohne",
+      "dubsync.scan_movies_ok":
+        "keine Episodennummern in den Dateinamen — für Filme in Ordnung",
+      "dubsync.step2": "2. Serie / Film",
+      "dubsync.step2_hint":
+        "Suche nach der Serie oder dem Film, aus der bzw. dem der Dub kommen soll.",
+      "dubsync.search": "Suchen",
+      "dubsync.searching": "Suche läuft…",
+      "dubsync.search_failed": "Suche fehlgeschlagen: ",
+      "dubsync.no_results": "Keine Ergebnisse",
+      "dubsync.loading_seasons": "Episodenliste wird geladen…",
+      "dubsync.load_failed": "Episoden konnten nicht geladen werden: ",
+      "dubsync.change_show": "Ändern",
+      "dubsync.season_one": "Staffel",
+      "dubsync.season_many": "Staffeln",
+      "dubsync.step3": "3. Episoden & Filme",
+      "dubsync.step3_hint":
+        "Episoden mit passenden lokalen Dateien sind vorausgewählt. Filmdateinamen tragen keine Episodennummern, daher hat jeder Film ein Dropdown zur Bestätigung seiner lokalen Datei. Passe die Auswahl vor dem Einreihen an.",
+      "dubsync.season_label": "Staffel",
+      "dubsync.movies": "Filme",
+      "dubsync.movies_hint":
+        "Wähle für jeden Film die lokale Datei; der beste Titel-Treffer ist vorausgewählt.",
+      "dubsync.movie_source": "Film",
+      "dubsync.movie_n": "Film",
+      "dubsync.movie_no_file": "— lokale Datei wählen —",
+      "dubsync.movie_need_file": "Wähle zuerst eine lokale Datei",
+      "dubsync.no_dub": "Kein deutscher Dub verfügbar",
+      "dubsync.local_file": "Lokale Datei: ",
+      "dubsync.unpaired": "lokale Datei(en) ohne passende Episode: ",
+      "dubsync.unparsed_note": "Nicht erkannt: ",
+      "dubsync.step4": "4. Optionen",
+      "dubsync.step4_hint":
+        "Die Voreinstellungen passen für die meisten Aufträge — du kannst einfach auf „Zur Warteschlange“ drücken.",
+      "dubsync.offset": "Dub-Timing (Sekunden)",
+      "dubsync.offset_auto": "automatisch",
+      "dubsync.offset_desc":
+        "Leer lassen — das Timing wird automatisch ermittelt.",
+      "dubsync.offset_tip":
+        "Nur nötig, wenn der Dub in jeder Episode gleichmäßig zu früh oder zu spät kommt. Beispiel: -0.5 lässt den Dub eine halbe Sekunde früher starten. Ein Wert hier schaltet das automatische Timing oben aus.",
+      "dubsync.auto_align": "Timing automatisch anpassen (empfohlen)",
+      "dubsync.auto_align_desc":
+        "Richtet den Dub am Video aus, indem beide Tonspuren verglichen werden.",
+      "dubsync.auto_align_tip":
+        "Der Dub stammt aus einem Stream, der etwas früher oder später starten kann als deine Datei. DubSync achtet auf Musik und Soundeffekte, die beide Fassungen teilen, und verschiebt den Dub passend. Ist es sich nicht sicher, bleibt das Timing unverändert und der Auftrag wird in der Warteschlange markiert, damit du per Ohr prüfen kannst.",
+      "dubsync.allow_resample": "Falsche Abspielgeschwindigkeit korrigieren",
+      "dubsync.allow_resample_desc":
+        "Manche Dubs laufen etwas zu schnell; das bremst den Dub passend zum Video ab.",
+      "dubsync.allow_resample_tip":
+        "Dubs aus TV-Ausstrahlungen laufen manchmal ca. 4 % zu schnell. Die Korrektur wandelt nur die Dub-Spur einmal um — dein Video und sein Originalton werden nie angefasst. Greift nur, wenn tatsächlich ein Geschwindigkeitsunterschied gefunden wird.",
+      "dubsync.cleanup": "Dub direkt in meine Dateien einfügen",
+      "dubsync.cleanup_desc":
+        "Wenn aus, wird eine neue Kopie namens *.dubsync.mkv neben jeder Datei gespeichert — die sichere Wahl.",
+      "dubsync.cleanup_tip":
+        "Auch wenn eingeschaltet: dein Original wird erst ersetzt, nachdem die neue Version vollständig und erfolgreich geschrieben wurde — ein fehlgeschlagener Auftrag beschädigt deine Dateien nie.",
+      "dubsync.add": "Zur Warteschlange",
+      "dubsync.added": "Hinzugefügt",
+      "dubsync.view_queue": "Warteschlange öffnen",
+      "dubsync.summary_incomplete": "Wähle zuerst einen Ordner und eine Serie",
+      "dubsync.summary_one": "Episode ausgewählt",
+      "dubsync.summary_many": "Episoden ausgewählt",
+      "dubsync.summary_movie_one": "Film ausgewählt",
+      "dubsync.summary_movie_many": "Filme ausgewählt",
+      "dubsync.queued": "DubSync-Auftrag zur Warteschlange hinzugefügt",
+      "dubsync.queue_failed": "Einreihen fehlgeschlagen: ",
+      "dubsync.browser_title": "Ordner auswählen",
+      "dubsync.browser_up": "← Zurück",
+      "dubsync.browser_select": "Diesen Ordner verwenden",
+      "dubsync.browser_empty": "Keine Unterordner",
+      "dubsync.browser_videos": "Videodatei(en) in diesem Ordner",
       "settings.discord": "Discord-Anfrage-Bot",
       "settings.discord.enable": "Discord-Bot aktivieren",
       "settings.discord.enable_hint":

--- a/src/aniworld/web/static/settings.js
+++ b/src/aniworld/web/static/settings.js
@@ -47,9 +47,38 @@ async function loadSettings() {
     if (movieFolder) movieFolder.checked = data.movie_folder !== "0";
 
     if (data.discord) applyDiscordSettings(data.discord);
+    if (data.dubsync) applyDubsyncSettings(data.dubsync);
   } catch (e) {
     showToast("Failed to load settings: " + e.message);
   }
+}
+
+// ===== DubSync =====
+
+function applyDubsyncSettings(d) {
+  const targetDir = document.getElementById("dubsyncTargetDir");
+  const offset = document.getElementById("dubsyncOffset");
+  const autoAlign = document.getElementById("dubsyncAutoAlign");
+  const allowResample = document.getElementById("dubsyncAllowResample");
+  const cleanup = document.getElementById("dubsyncCleanup");
+  if (targetDir) targetDir.value = d.target_dir || "";
+  if (offset) offset.value = d.offset || "";
+  if (autoAlign) autoAlign.checked = d.auto_align !== "0";
+  if (allowResample) allowResample.checked = d.allow_resample === "1";
+  if (cleanup) cleanup.checked = d.cleanup === "1";
+}
+
+function saveDubsyncDefaults() {
+  const payload = {
+    dubsync: {
+      target_dir: document.getElementById("dubsyncTargetDir").value.trim(),
+      offset: document.getElementById("dubsyncOffset").value.trim(),
+      auto_align: document.getElementById("dubsyncAutoAlign").checked,
+      allow_resample: document.getElementById("dubsyncAllowResample").checked,
+      cleanup: document.getElementById("dubsyncCleanup").checked,
+    },
+  };
+  putSettings(payload, t("settings.dubsync_saved", "DubSync defaults saved"));
 }
 
 async function putSettings(payload, successMsg) {

--- a/src/aniworld/web/static/style.css
+++ b/src/aniworld/web/static/style.css
@@ -774,6 +774,88 @@ h1 {
   backdrop-filter: blur(8px);
 }
 
+.toast.show {
+  display: block;
+  animation: toast-in 0.2s ease-out;
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ===== Per-download options (modal) ===== */
+.dl-options {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dl-opt-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 0.88rem;
+  color: #c8cad0;
+  cursor: pointer;
+}
+
+.dl-opt-row input[type="checkbox"] {
+  accent-color: #2563eb;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.dl-opt-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #8b8fa3;
+}
+
+.dl-opt-checks {
+  display: inline-flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.dl-opt-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+}
+
+/* Small circled "?" whose title attribute explains an option */
+.ds-help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #8b8fa3;
+  font-size: 0.68rem;
+  font-weight: 700;
+  cursor: help;
+  user-select: none;
+}
+
+.ds-help:hover {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
 /* ===== Navbar ===== */
 /* (already defined above in Top bar section) */
 

--- a/src/aniworld/web/templates/base.html
+++ b/src/aniworld/web/templates/base.html
@@ -35,6 +35,10 @@
       <a href="{{ url_for('index') }}" class="top-bar-link" data-i18n="nav.home">Home</a>
       <a href="{{ url_for('library_page') }}" class="top-bar-link" data-i18n="nav.library">Library</a>
       <a href="{{ url_for('autosync_page') }}" class="top-bar-link" data-i18n="nav.autosync">Auto-Sync</a>
+      {% if not auth_enabled or (current_user and current_user.role ==
+      'admin') %}
+      <a href="{{ url_for('dubsync_page') }}" class="top-bar-link" data-i18n="nav.dubsync">DubSync</a>
+      {% endif %}
       <a href="{{ url_for('planned_page') }}" class="top-bar-link" data-i18n="nav.planned">Planned</a>
       <a href="#" class="top-bar-link" id="queueBtn" onclick="
             openQueueModal();

--- a/src/aniworld/web/templates/dubsync.html
+++ b/src/aniworld/web/templates/dubsync.html
@@ -1,0 +1,236 @@
+{% extends "base.html" %} {% block title %}DubSync — AniWorld Downloader{%
+endblock %} {% block content %}
+<div class="settings-container" style="max-width: 1100px">
+  <h1>DubSync</h1>
+  <p class="settings-hint" style="margin-bottom: 24px" data-i18n="dubsync.page_hint">
+    Graft a German dub from AniWorld, SerienStream or a movie site losslessly
+    onto your own archive-quality series and movie files as an additional
+    audio track.
+  </p>
+
+  <!-- Step 1: local folder -->
+  <div class="settings-section">
+    <h2><span data-i18n="dubsync.step1">1. Local folder</span></h2>
+    <div class="settings-hint" data-i18n="dubsync.step1_hint">
+      Pick the folder that holds your local video files. Filenames are scanned
+      for season/episode numbers; movie files don't need any.
+    </div>
+    <div class="settings-row" style="margin-top: 10px">
+      <input type="text" id="dsFolder" placeholder="/path/to/local/videos" onchange="dsFolderChanged()" />
+      <button onclick="dsOpenBrowser()" data-i18n="dubsync.browse">Browse…</button>
+    </div>
+    <label class="settings-checkbox" style="
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 12px;
+        font-size: 0.88rem;
+        color: #c8cad0;
+        cursor: pointer;
+      ">
+      <input type="checkbox" id="dsRecursive" onchange="dsFolderChanged()" style="accent-color: #2563eb; cursor: pointer" />
+      <span data-i18n="dubsync.recursive">Include subfolders</span>
+    </label>
+    <div id="dsScanInfo" class="settings-hint" style="margin-top: 10px"></div>
+    <div id="dsScanFiles" style="margin-top: 8px"></div>
+  </div>
+
+  <!-- Step 2: show search -->
+  <div class="settings-section">
+    <h2><span data-i18n="dubsync.step2">2. Show</span></h2>
+    <div class="settings-hint" data-i18n="dubsync.step2_hint">
+      Search for the show or movie the dub should come from.
+    </div>
+    <div class="settings-row" style="margin-top: 10px">
+      <select id="dsSite" class="sync-select" style="max-width: 160px">
+        <option value="aniworld">AniWorld</option>
+        <option value="sto">SerienStream</option>
+        <option value="megakino">MegaKino</option>
+        <option value="filmpalast">FilmPalast</option>
+      </select>
+      <input type="text" id="dsSearch" placeholder="Search…" onkeydown="if (event.key === 'Enter') dsSearchShows()" />
+      <button onclick="dsSearchShows()" data-i18n="dubsync.search">Search</button>
+    </div>
+    <div id="dsResults" style="margin-top: 12px"></div>
+    <div id="dsShowHeader" style="display: none; margin-top: 12px"></div>
+  </div>
+
+  <!-- Step 3: episodes -->
+  <div class="settings-section" id="dsEpisodesSection" style="display: none">
+    <h2><span data-i18n="dubsync.step3">3. Episodes &amp; movies</span></h2>
+    <div class="settings-hint" data-i18n="dubsync.step3_hint">
+      Episodes matching your local files are pre-selected. Movies have no
+      episode numbers in their filenames, so each one gets a dropdown to
+      confirm its local file. Adjust the selection before queueing.
+    </div>
+    <div id="dsSeasons" style="margin-top: 12px"></div>
+    <div id="dsMatchWarnings" style="margin-top: 10px"></div>
+  </div>
+
+  <!-- Step 4: options + enqueue -->
+  <style>
+    .ds-help {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+      border-radius: 50%;
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      color: #8b8fa3;
+      font-size: 0.68rem;
+      font-weight: 700;
+      cursor: help;
+      user-select: none;
+    }
+    .ds-help:hover {
+      color: #fff;
+      border-color: rgba(255, 255, 255, 0.5);
+    }
+    .ds-opt {
+      margin-top: 16px;
+    }
+    .ds-opt-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.9rem;
+      color: #e0e0e0;
+      cursor: pointer;
+    }
+    .ds-opt-label input[type="checkbox"] {
+      accent-color: #2563eb;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .ds-opt .settings-hint {
+      margin: 4px 0 0 24px;
+    }
+    #dsOffset {
+      width: 140px;
+      margin-top: 8px;
+      padding: 9px 14px;
+      border-radius: 10px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      background: rgba(255, 255, 255, 0.04);
+      color: #e0e0e0;
+      font-size: 0.9rem;
+      outline: none;
+      font-family: "SF Mono", "Fira Code", monospace;
+      transition:
+        border-color 0.2s,
+        box-shadow 0.2s;
+    }
+    #dsOffset:focus {
+      border-color: #2563eb;
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+    }
+    #dsOffset::placeholder {
+      color: #6b6f7e;
+    }
+  </style>
+  <div class="settings-section">
+    <h2><span data-i18n="dubsync.step4">4. Options</span></h2>
+    <div class="settings-hint" data-i18n="dubsync.step4_hint">
+      The usual settings work for most jobs — you can just press Add to queue.
+    </div>
+
+    <div class="ds-opt">
+      <label class="ds-opt-label">
+        <input type="checkbox" id="dsAutoAlign" />
+        <span data-i18n="dubsync.auto_align">Fix timing automatically (recommended)</span>
+        <span class="ds-help" data-i18n-title="dubsync.auto_align_tip" title="The dub comes from a stream that may start a little earlier or later than your file. DubSync listens for the music and sound effects both versions share and shifts the dub so it lines up. If it is not confident, it leaves the timing as-is and marks the job in the queue so you can check by ear.">?</span>
+      </label>
+      <div class="settings-hint" data-i18n="dubsync.auto_align_desc">
+        Lines the dub up with your video by comparing the two soundtracks.
+      </div>
+    </div>
+
+    <div class="ds-opt">
+      <label class="ds-opt-label">
+        <input type="checkbox" id="dsAllowResample" />
+        <span data-i18n="dubsync.allow_resample">Fix wrong playback speed</span>
+        <span class="ds-help" data-i18n-title="dubsync.allow_resample_tip" title="Dubs taken from TV broadcasts sometimes run about 4% too fast. Fixing that means the dub track is converted once — your video and its original audio are never touched. Only kicks in when a speed difference is actually found.">?</span>
+      </label>
+      <div class="settings-hint" data-i18n="dubsync.allow_resample_desc">
+        Some dubs run slightly too fast; this slows the dub down to match your
+        video.
+      </div>
+    </div>
+
+    <div class="ds-opt">
+      <label class="ds-opt-label">
+        <input type="checkbox" id="dsCleanup" />
+        <span data-i18n="dubsync.cleanup">Add the dub directly into my files</span>
+        <span class="ds-help" data-i18n-title="dubsync.cleanup_tip" title="Even with this on, your original is only replaced after the new version was written completely and successfully — a failed job never damages your files.">?</span>
+      </label>
+      <div class="settings-hint" data-i18n="dubsync.cleanup_desc">
+        When off, a new copy named *.dubsync.mkv is saved next to each file —
+        the safe choice.
+      </div>
+    </div>
+
+    <div class="ds-opt">
+      <label class="ds-opt-label" style="cursor: default">
+        <span data-i18n="dubsync.offset">Dub timing (seconds)</span>
+        <span class="ds-help" data-i18n-title="dubsync.offset_tip" title="Only needed when the dub is consistently too early or too late in every episode. Example: -0.5 starts the dub half a second earlier. Entering a value here turns off the automatic timing above.">?</span>
+      </label>
+      <input type="text" id="dsOffset" data-i18n-placeholder="dubsync.offset_auto" placeholder="automatic" />
+      <div class="settings-hint" style="margin-left: 0" data-i18n="dubsync.offset_desc">
+        Leave empty — the timing is worked out automatically.
+      </div>
+    </div>
+
+    <div class="settings-row" style="margin-top: 22px; align-items: center; gap: 14px">
+      <button id="dsEnqueueBtn" onclick="dsEnqueue()" disabled data-i18n="dubsync.add">Add to queue</button>
+      <span id="dsSummary" class="settings-hint" style="margin: 0"></span>
+    </div>
+  </div>
+</div>
+
+<!-- Folder browser modal -->
+<div class="overlay" id="dsBrowserOverlay" onclick="if (event.target === this) dsCloseBrowser();">
+  <div class="modal" style="max-width: 560px">
+    <button class="close" onclick="dsCloseBrowser()">&times;</button>
+    <h2 style="color: #fff; margin-bottom: 4px" data-i18n="dubsync.browser_title">Choose a folder</h2>
+    <div id="dsBrowserPath" style="
+        color: #6ea8fe;
+        font-size: 0.85rem;
+        margin-bottom: 12px;
+        word-break: break-all;
+      "></div>
+    <div id="dsBrowserVideos" class="settings-hint" style="margin-bottom: 8px"></div>
+    <div id="dsBrowserList" style="
+        max-height: 340px;
+        overflow-y: auto;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 10px;
+        margin-bottom: 16px;
+      "></div>
+    <div style="display: flex; justify-content: space-between; gap: 10px">
+      <button id="dsBrowserUp" onclick="dsBrowserUp()" style="
+          padding: 10px 20px;
+          border-radius: 10px;
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          background: rgba(255, 255, 255, 0.04);
+          color: #c8cad0;
+          font-size: 0.85rem;
+          cursor: pointer;
+        " data-i18n="dubsync.browser_up">&#8592; Back</button>
+      <button onclick="dsBrowserSelect()" style="
+          padding: 10px 20px;
+          border-radius: 10px;
+          border: none;
+          background: linear-gradient(135deg, #2563eb, #1d4ed8);
+          color: #fff;
+          font-size: 0.85rem;
+          font-weight: 600;
+          cursor: pointer;
+        " data-i18n="dubsync.browser_select">Use this folder</button>
+    </div>
+  </div>
+</div>
+{% endblock %} {% block scripts %}
+<script src="{{ url_for('static', filename='dubsync.js') }}"></script>
+{% endblock %}

--- a/src/aniworld/web/templates/index.html
+++ b/src/aniworld/web/templates/index.html
@@ -120,6 +120,20 @@
         <option value="" data-i18n="index.default">Default</option>
       </select>
     </div>
+    <div class="dl-options" id="dlOptions">
+      <div class="dl-opt-row" id="extraLangsRow" style="display: none">
+        <span class="dl-opt-label">
+          <span data-i18n="index.extra_langs">Also download:</span>
+          <span class="ds-help" data-i18n-title="index.extra_langs_tip" title="Everything ends up in one file: each extra dub becomes another audio track you can switch to in your player, timed to match automatically. Sub versions have their subtitles burned into the picture, so they are added as a second video track you can switch to instead.">?</span>
+        </span>
+        <span id="extraLangChecks" class="dl-opt-checks"></span>
+      </div>
+      <label class="dl-opt-row" id="fetchSubsRow" style="display: none">
+        <input type="checkbox" id="fetchSubsCheck" />
+        <span data-i18n="index.fetch_subs">Add a real German subtitle track</span>
+        <span class="ds-help" data-i18n-title="index.fetch_subs_tip" title="Downloads the official German subtitles for this episode from the fansub scene and puts them into the file as subtitles you can turn on and off. Works for most anime from around 2020 onwards; if none are found the download simply completes without them.">?</span>
+      </label>
+    </div>
     <script>
       window.ANIWORLD_LANGS = {{ lang_labels | tojson }};
       window.STO_LANGS = {{ sto_lang_labels | tojson }};

--- a/src/aniworld/web/templates/settings.html
+++ b/src/aniworld/web/templates/settings.html
@@ -224,6 +224,77 @@ endblock %} {% block content %}
   </div>
 
   <div class="settings-section">
+    <h2 data-i18n="settings.dubsync">DubSync</h2>
+    <div class="settings-hint" data-i18n="settings.dubsync_hint">
+      Defaults for the DubSync page (see the DubSync tab in the navigation).
+      Each queued job can override them.
+    </div>
+
+    <h3 class="settings-subtitle" data-i18n="settings.dubsync_defaults">Defaults</h3>
+    <div class="settings-row">
+      <input type="text" id="dubsyncTargetDir" placeholder="/path/to/local/videos" />
+      <button onclick="saveDubsyncDefaults()">Save</button>
+    </div>
+    <div class="settings-hint" data-i18n="settings.dubsync_target_hint">
+      Default local video folder, used to prefill the DubSync page.
+    </div>
+    <div class="settings-row" style="gap: 10px; flex-wrap: wrap; margin-top: 10px">
+      <div style="flex: 1; min-width: 160px">
+        <label class="planned-label" data-i18n="settings.dubsync_offset">Manual offset (seconds)</label>
+        <input type="text" id="dubsyncOffset" placeholder="auto" style="width: 100%" onchange="saveDubsyncDefaults()" />
+      </div>
+    </div>
+    <label class="settings-checkbox" style="
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 14px;
+        font-size: 0.88rem;
+        color: #c8cad0;
+        cursor: pointer;
+      ">
+      <input type="checkbox" id="dubsyncAutoAlign" onchange="saveDubsyncDefaults()" style="accent-color: #2563eb; cursor: pointer" />
+      <span data-i18n="settings.dubsync_auto_align">Automatic audio alignment</span>
+    </label>
+    <div class="settings-hint" data-i18n="settings.dubsync_auto_align_hint">
+      Detect each episode's dub offset by correlating the shared music/SFX bed.
+      A manual offset always overrides detection.
+    </div>
+    <label class="settings-checkbox" style="
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 14px;
+        font-size: 0.88rem;
+        color: #c8cad0;
+        cursor: pointer;
+      ">
+      <input type="checkbox" id="dubsyncAllowResample" onchange="saveDubsyncDefaults()" style="accent-color: #2563eb; cursor: pointer" />
+      <span data-i18n="settings.dubsync_allow_resample">Correct drift (re-encodes the dub track)</span>
+    </label>
+    <div class="settings-hint" data-i18n="settings.dubsync_allow_resample_hint">
+      Fixes PAL-speed dubs (~4% fast) via atempo. Only the added dub track is
+      re-encoded; video and original audio stay untouched.
+    </div>
+    <label class="settings-checkbox" style="
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 14px;
+        font-size: 0.88rem;
+        color: #c8cad0;
+        cursor: pointer;
+      ">
+      <input type="checkbox" id="dubsyncCleanup" onchange="saveDubsyncDefaults()" style="accent-color: #2563eb; cursor: pointer" />
+      <span data-i18n="settings.dubsync_cleanup">Edit files in place</span>
+    </label>
+    <div class="settings-hint" data-i18n="settings.dubsync_cleanup_hint">
+      When off, results are written as *.dubsync.mkv copies next to the
+      originals (safe default).
+    </div>
+  </div>
+
+  <div class="settings-section">
     <h2 data-i18n="settings.discord">Discord Request Bot</h2>
     <label class="settings-checkbox" style="
         display: flex;

--- a/tests/test_dubsync_align.py
+++ b/tests/test_dubsync_align.py
@@ -1,0 +1,157 @@
+"""Unit tests for the DubSync alignment engine (synthetic signals).
+
+The correlation math is tested directly on synthesized envelopes/PCM: two
+tracks sharing an impulse "music bed" but carrying different "dialogue" noise
+must align at the known shift with high confidence, while unrelated noise must
+come back low-confidence. The full decode path is exercised through real WAV
+files when ffmpeg is available.
+"""
+
+import shutil
+import wave
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from aniworld.models.aniworld_to.dubsync.align import (
+    _DECODE_RATE,
+    _ENVELOPE_RATE,
+    DEFAULT_MIN_CONFIDENCE,
+    _onset_envelope,
+    _xcorr_peak,
+    detect_offset,
+)
+
+def _impulse_bed(rng, duration_s: float, n_events: int = 60) -> np.ndarray:
+    """Silent track with short loud noise bursts at random times -- a stand-in
+    for the shared music/SFX bed."""
+
+    samples = np.zeros(int(duration_s * _DECODE_RATE), dtype=np.float32)
+    burst_len = _DECODE_RATE // 10  # 100 ms
+    positions = rng.integers(0, len(samples) - burst_len, n_events)
+    for pos in positions:
+        samples[pos : pos + burst_len] += 0.7 * rng.standard_normal(burst_len).astype(
+            np.float32
+        )
+    return samples
+
+
+def _dialogue(rng, duration_s: float, level: float = 0.08) -> np.ndarray:
+    """Continuous low-level noise -- a stand-in for (language-specific) speech."""
+
+    return level * rng.standard_normal(int(duration_s * _DECODE_RATE)).astype(
+        np.float32
+    )
+
+
+def _write_wav(path: Path, samples: np.ndarray) -> None:
+    pcm = (np.clip(samples, -1.0, 1.0) * 32767).astype("<i2")
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(_DECODE_RATE)
+        wav.writeframes(pcm.tobytes())
+
+
+def test_xcorr_recovers_known_shift():
+    rng = np.random.default_rng(42)
+    bed = _impulse_bed(rng, 120.0)
+    ref_env = _onset_envelope(bed + _dialogue(rng, 120.0))
+
+    shift_s = 2.5
+    pad = np.zeros(int(shift_s * _DECODE_RATE), dtype=np.float32)
+    dub_env = _onset_envelope(np.concatenate([pad, bed]) + _dialogue(rng, 122.5))
+
+    max_lag = 30 * _ENVELOPE_RATE
+    lag, confidence = _xcorr_peak(ref_env, dub_env, -max_lag, max_lag)
+
+    # Dub content occurs later, so it must be advanced: negative lag.
+    assert lag / _ENVELOPE_RATE == pytest.approx(-shift_s, abs=0.05)
+    assert confidence >= DEFAULT_MIN_CONFIDENCE
+
+
+def test_uncorrelated_noise_is_low_confidence():
+    rng = np.random.default_rng(43)
+    env_a = _onset_envelope(_dialogue(rng, 120.0, level=0.3))
+    env_b = _onset_envelope(_dialogue(rng, 120.0, level=0.3))
+
+    max_lag = 30 * _ENVELOPE_RATE
+    _, confidence = _xcorr_peak(env_a, env_b, -max_lag, max_lag)
+
+    assert confidence < DEFAULT_MIN_CONFIDENCE
+
+
+def test_silence_yields_zero_confidence():
+    silent = _onset_envelope(np.zeros(60 * _DECODE_RATE, dtype=np.float32))
+    lag, confidence = _xcorr_peak(silent, silent, -100, 100)
+    assert lag == 0.0
+    assert confidence == 0.0
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not on PATH")
+def test_detect_offset_end_to_end(tmp_path):
+    rng = np.random.default_rng(44)
+    bed = _impulse_bed(rng, 90.0)
+    ref = bed + _dialogue(rng, 90.0)
+
+    shift_s = 1.5
+    pad = np.zeros(int(shift_s * _DECODE_RATE), dtype=np.float32)
+    dub = np.concatenate([pad, bed]) + _dialogue(rng, 91.5)
+
+    ref_path = tmp_path / "ref.wav"
+    dub_path = tmp_path / "dub.wav"
+    _write_wav(ref_path, ref)
+    _write_wav(dub_path, dub)
+
+    result = detect_offset(dub_path, ref_path, max_offset=30.0)
+
+    assert result.offset == pytest.approx(-shift_s, abs=0.05)
+    assert result.confidence >= DEFAULT_MIN_CONFIDENCE
+    # 90 s is far below the drift-check minimum, so no drift is reported.
+    assert result.drift == 0.0
+    assert result.tempo_ratio == 1.0
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not on PATH")
+def test_detect_offset_finds_pal_drift(tmp_path):
+    rng = np.random.default_rng(45)
+    speed = 25 / 23.976  # PAL speed-up: the classic German-dub drift case
+    bed = _impulse_bed(rng, 600.0, n_events=300)
+    ref = bed + _dialogue(rng, 600.0)
+
+    # Dub plays `speed` times too fast: dub[i] = bed[i * speed].
+    idx = np.arange(int(len(bed) / speed)) * speed
+    dub = np.interp(idx, np.arange(len(bed)), bed).astype(np.float32)
+    dub += _dialogue(rng, len(dub) / _DECODE_RATE)
+
+    ref_path = tmp_path / "ref.wav"
+    dub_path = tmp_path / "dub.wav"
+    _write_wav(ref_path, ref)
+    _write_wav(dub_path, dub)
+
+    result = detect_offset(dub_path, ref_path, max_offset=60.0)
+
+    assert result.has_drift
+    assert result.tempo_ratio == pytest.approx(1 / speed, abs=1e-4)
+    assert result.drift_confidence >= DEFAULT_MIN_CONFIDENCE
+    assert result.post_tempo_offset == pytest.approx(0.0, abs=0.1)
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not on PATH")
+def test_no_false_drift_on_clean_alignment(tmp_path):
+    rng = np.random.default_rng(46)
+    bed = _impulse_bed(rng, 600.0, n_events=300)
+    ref = bed + _dialogue(rng, 600.0)
+    dub = bed + _dialogue(rng, 600.0)
+
+    ref_path = tmp_path / "ref.wav"
+    dub_path = tmp_path / "dub.wav"
+    _write_wav(ref_path, ref)
+    _write_wav(dub_path, dub)
+
+    result = detect_offset(dub_path, ref_path, max_offset=60.0)
+
+    assert result.offset == pytest.approx(0.0, abs=0.05)
+    assert not result.has_drift
+    assert result.tempo_ratio == 1.0

--- a/tests/test_multilang_merge.py
+++ b/tests/test_multilang_merge.py
@@ -1,0 +1,266 @@
+"""Regression tests for merging a second language into an existing download.
+
+Downloading the same episode again in another language used to concatenate the
+new stream with a plain ``-c copy``, so the added track played out of sync with
+the video (upstream issue: "the audio track from the language downloaded second
+was noticeably late"). The merge now detects the offset and applies it, which
+is what these tests pin down:
+
+* the appended track ends up aligned with the one already in the file,
+* it is tagged and marked non-default so players keep the original primary,
+* everything stays in ONE file (extra dub -> audio track, hardsubbed "Sub"
+  variant -> additional video+audio pair).
+
+Media is synthesised with ffmpeg; no network access is involved.
+"""
+
+import json
+import shutil
+import subprocess
+import wave
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from aniworld.models.aniworld_to.dubsync.align import _DECODE_RATE, detect_offset
+from aniworld.models.common.common import (
+    _detect_merge_offset,
+    _merge_audio_aligned,
+    _merge_full_stream_aligned,
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="ffmpeg/ffprobe not on PATH",
+)
+
+DURATION_S = 40.0
+LEAD_IN_S = 1.5
+
+
+def _shared_bed(seed: int, duration_s: float = DURATION_S) -> np.ndarray:
+    """Noise bursts with a random envelope -- the music/SFX bed both language
+    versions share, and the only thing the aligner can lock onto."""
+
+    rng = np.random.default_rng(seed)
+    frames = int(duration_s * 10)
+    envelope = np.repeat(rng.random(frames) > 0.5, _DECODE_RATE // 10)
+    noise = rng.standard_normal(len(envelope)).astype(np.float32)
+    return 0.3 * noise * envelope.astype(np.float32)
+
+
+def _write_wav(path: Path, samples: np.ndarray) -> None:
+    pcm = (np.clip(samples, -1.0, 1.0) * 32767).astype("<i2")
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(_DECODE_RATE)
+        wav.writeframes(pcm.tobytes())
+
+
+def _ffmpeg(*args: str) -> None:
+    subprocess.run(
+        ["ffmpeg", "-y", "-v", "error", *args],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _make_video(dest: Path, audio: Path, lang: str, pattern: str = "testsrc") -> Path:
+    """Tiny video file carrying `audio` as its single, language-tagged track."""
+
+    _ffmpeg(
+        "-f", "lavfi", "-i", f"{pattern}=size=160x90:rate=10:duration={DURATION_S + 5}",
+        "-i", str(audio),
+        "-c:v", "libx264", "-preset", "ultrafast", "-c:a", "aac",
+        "-metadata:s:a:0", f"language={lang}",
+        "-shortest", str(dest),
+    )
+    return dest
+
+
+def _streams(path: Path) -> list[dict]:
+    probe = subprocess.run(
+        ["ffprobe", "-v", "quiet", "-print_format", "json", "-show_streams", str(path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(probe.stdout)["streams"]
+
+
+def _residual_offset(path: Path, first: int = 0, second: int = 1) -> float:
+    """Seconds the second audio track is still out of sync with the first.
+
+    Extracting a track to WAV re-bases it at zero, discarding the container
+    start_time that carries the applied ``-itsoffset``; the delta between the
+    two start times has to be added back or a perfectly aligned file looks
+    misaligned by exactly the offset that fixed it.
+    """
+
+    audio = [s for s in _streams(path) if s["codec_type"] == "audio"]
+    start_delta = float(audio[second].get("start_time") or 0) - float(
+        audio[first].get("start_time") or 0
+    )
+
+    extracted = []
+    for index in (first, second):
+        out = path.with_name(f"{path.stem}.a{index}.wav")
+        _ffmpeg("-i", str(path), "-map", f"0:a:{index}", str(out))
+        extracted.append(out)
+
+    content_offset = detect_offset(extracted[1], extracted[0], max_offset=30.0).offset
+    return start_delta - content_offset
+
+
+@pytest.fixture
+def episode_with_delayed_second_language(tmp_path):
+    """An existing download plus a second-language stream that starts late.
+
+    The second stream carries the same bed behind `LEAD_IN_S` of extra silence,
+    i.e. exactly the situation that used to produce a late audio track.
+    """
+
+    bed = _shared_bed(seed=7)
+    lead_in = np.zeros(int(LEAD_IN_S * _DECODE_RATE), dtype=np.float32)
+
+    original_wav = tmp_path / "original.wav"
+    delayed_wav = tmp_path / "delayed.wav"
+    _write_wav(original_wav, bed)
+    _write_wav(delayed_wav, np.concatenate([lead_in, bed]))
+
+    episode = _make_video(tmp_path / "episode.mkv", original_wav, "deu")
+    return episode, original_wav, delayed_wav
+
+
+def test_second_dub_is_merged_in_sync(episode_with_delayed_second_language, tmp_path):
+    """The reported bug: a second dub must not end up playing late."""
+
+    episode, _, delayed_wav = episode_with_delayed_second_language
+    extra_audio = tmp_path / "extra_audio.mkv"
+    _ffmpeg(
+        "-i", str(delayed_wav), "-c:a", "aac",
+        "-metadata:s:a:0", "language=eng", str(extra_audio),
+    )
+
+    _merge_audio_aligned(episode, extra_audio, "eng", "test-episode")
+
+    audio = [s for s in _streams(episode) if s["codec_type"] == "audio"]
+    assert len(audio) == 2, "the second language must land in the same file"
+    assert audio[1]["tags"]["language"] == "eng"
+    assert audio[1]["disposition"]["default"] == 0, "original stays the default track"
+    assert _residual_offset(episode) == pytest.approx(0.0, abs=0.1)
+
+
+def test_sub_variant_merges_as_extra_video_and_audio(
+    episode_with_delayed_second_language, tmp_path
+):
+    """Hardsubbed "Sub" variants bring their own video; both streams are
+    appended to the same file, shifted together and left non-default."""
+
+    episode, _, delayed_wav = episode_with_delayed_second_language
+    # testsrc2 so the appended video is visibly a different encode.
+    sub_variant = _make_video(
+        tmp_path / "sub_variant.mkv", delayed_wav, "jpn", pattern="testsrc2"
+    )
+
+    _merge_full_stream_aligned(episode, sub_variant, "test-episode")
+
+    streams = _streams(episode)
+    video = [s for s in streams if s["codec_type"] == "video"]
+    audio = [s for s in streams if s["codec_type"] == "audio"]
+    assert len(video) == 2 and len(audio) == 2
+    assert video[1]["disposition"]["default"] == 0
+    assert audio[1]["disposition"]["default"] == 0
+    assert _residual_offset(episode) == pytest.approx(0.0, abs=0.1)
+    # The appended video must keep the same shift as the audio it came with,
+    # otherwise the sub variant would be internally out of sync.
+    assert float(video[1]["start_time"]) == pytest.approx(
+        float(audio[1]["start_time"]), abs=0.15
+    )
+
+
+def test_alignment_can_be_disabled(episode_with_delayed_second_language, monkeypatch):
+    """--no-merge-align / ANIWORLD_MERGE_ALIGN=0 restores the unshifted merge."""
+
+    episode, _, delayed_wav = episode_with_delayed_second_language
+    monkeypatch.setenv("ANIWORLD_MERGE_ALIGN", "0")
+
+    assert _detect_merge_offset(delayed_wav, episode, "second track") == (0.0, None)
+
+
+def test_unrelated_audio_is_not_shifted_on_a_guess(tmp_path):
+    """Below the confidence threshold the merge must fall back to no shift
+    rather than trusting a spurious correlation peak."""
+
+    reference = tmp_path / "reference.wav"
+    unrelated = tmp_path / "unrelated.wav"
+    _write_wav(reference, _shared_bed(seed=1))
+    _write_wav(unrelated, _shared_bed(seed=99))
+
+    assert _detect_merge_offset(unrelated, reference, "unrelated track") == (0.0, None)
+
+
+def _pal_speed_pair(seed: int, duration_s: float = 700.0):
+    """A reference bed plus the same bed running at PAL speed (~4 % fast).
+
+    German TV dubs are 25 fps where the original-language encode is 23.976,
+    which is exactly the case that broke live: no constant shift can align
+    them, and the shift measured while pretending otherwise is noise.
+    """
+
+    speed = 25 / 23.976
+    bed = _shared_bed(seed, duration_s)
+    index = np.arange(int(len(bed) / speed)) * speed
+    fast = np.interp(index, np.arange(len(bed)), bed).astype(np.float32)
+    return bed, fast
+
+
+def test_speed_mismatched_audio_is_retimed_not_shifted(tmp_path):
+    """The live failure: a PAL-speed dub must never be "aligned" with a
+    constant offset, because the offset measured under that assumption is
+    meaningless (it landed 95 s out on real Family Guy audio)."""
+
+    bed, fast = _pal_speed_pair(seed=3)
+    reference = tmp_path / "reference.wav"
+    faster = tmp_path / "faster.wav"
+    _write_wav(reference, bed)
+    _write_wav(faster, fast)
+
+    retime_to = tmp_path / "retimed.mka"
+    offset, retimed = _detect_merge_offset(
+        faster, reference, "pal dub", retime_to=retime_to
+    )
+
+    assert retimed == retime_to and retimed.exists(), "drift must be retimed"
+    # Post-retime the tracks start together, so only a small residual remains.
+    assert offset == pytest.approx(0.0, abs=1.0)
+
+
+def test_speed_mismatch_without_a_retime_target_is_not_shifted(tmp_path):
+    """A "Sub" variant brings its own video, so its audio cannot be retimed
+    independently — it must be merged unshifted rather than mis-shifted."""
+
+    bed, fast = _pal_speed_pair(seed=4)
+    reference = tmp_path / "reference.wav"
+    faster = tmp_path / "faster.wav"
+    _write_wav(reference, bed)
+    _write_wav(faster, fast)
+
+    assert _detect_merge_offset(faster, reference, "pal variant") == (0.0, None)
+
+
+def test_retiming_can_be_disabled(tmp_path, monkeypatch):
+    bed, fast = _pal_speed_pair(seed=5)
+    reference = tmp_path / "reference.wav"
+    faster = tmp_path / "faster.wav"
+    _write_wav(reference, bed)
+    _write_wav(faster, fast)
+    monkeypatch.setenv("ANIWORLD_MERGE_RESAMPLE", "0")
+
+    offset, retimed = _detect_merge_offset(
+        faster, reference, "pal dub", retime_to=tmp_path / "retimed.mka"
+    )
+    assert (offset, retimed) == (0.0, None)

--- a/tests/test_subfetch_matching.py
+++ b/tests/test_subfetch_matching.py
@@ -1,0 +1,108 @@
+"""Unit tests for the external subtitle fetcher's release matching.
+
+Picking the wrong release is worse than finding nothing: sequel seasons share
+almost all of their title words, so a naive similarity score happily returns
+season 1's subtitles for a season 2 episode. These tests pin the matching rules
+down without touching the network -- only the pure scoring/parsing helpers are
+exercised.
+"""
+
+import pytest
+
+from aniworld.models.aniworld_to.dubsync.subfetch import (
+    LANG_ALIASES,
+    MIN_TITLE_SCORE,
+    _episode_re,
+    _title_score,
+    _tokens,
+)
+
+FRIEREN_S1 = "Sousou no Frieren"
+FRIEREN_S2 = "Sousou no Frieren 2nd Season"
+
+
+def _release(title: str, episode: int, tags: str = "[1080p CR WEB-DL AVC AAC]") -> str:
+    return f"[Erai-raws] {title} - {episode:02d} {tags}[MultiSub][DEADBEEF]"
+
+
+@pytest.mark.parametrize(
+    "release_episode, wanted_episode, should_match",
+    [
+        (1, 1, True),
+        (13, 13, True),
+        (1, 11, False),  # "- 01" must not satisfy a search for episode 11
+        (11, 1, False),  # ...nor the reverse
+        (5, 15, False),
+    ],
+)
+def test_episode_number_must_match_exactly(
+    release_episode, wanted_episode, should_match
+):
+    matched = _episode_re(wanted_episode).search(_release(FRIEREN_S1, release_episode))
+    assert bool(matched) is should_match
+
+
+def test_versioned_release_still_matches():
+    """Scene re-releases append a version suffix ("- 05v2")."""
+
+    assert _episode_re(5).search("[Erai-raws] Sousou no Frieren - 05v2 [1080p]")
+
+
+def test_romanization_difference_is_folded():
+    """"Yume wo Minai" and "Yume o Minai" name the same show."""
+
+    assert _tokens("Yume wo Minai") == _tokens("Yume o Minai")
+
+
+def test_exact_title_scores_full_marks():
+    score = _title_score(_release(FRIEREN_S1, 1), FRIEREN_S1, 1)
+    assert score == pytest.approx(1.0)
+
+
+def test_sequel_season_is_rejected_for_season_one():
+    """The regression behind "no German subs for Frieren S2": a season 2
+    release must not be accepted when season 1 was asked for."""
+
+    score = _title_score(_release(FRIEREN_S2, 1), FRIEREN_S1, 1)
+    assert score < MIN_TITLE_SCORE
+
+
+def test_season_one_is_rejected_for_sequel_season():
+    score = _title_score(_release(FRIEREN_S1, 1), FRIEREN_S2, 1)
+    assert score < MIN_TITLE_SCORE
+
+
+def test_sequel_season_matches_its_own_title():
+    score = _title_score(_release(FRIEREN_S2, 1), FRIEREN_S2, 1)
+    assert score >= MIN_TITLE_SCORE
+
+
+def test_unrelated_show_scores_far_below_threshold():
+    score = _title_score(_release("Kimetsu no Yaiba", 1), FRIEREN_S1, 1)
+    assert score < MIN_TITLE_SCORE
+
+
+def test_release_tags_do_not_inflate_the_score():
+    """Quality/codec tags are noise and must not count as title words."""
+
+    verbose = _release(FRIEREN_S1, 1, tags="[1080p CR WEBRip HEVC EAC3 Multi Sub]")
+    assert _title_score(verbose, FRIEREN_S1, 1) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "spelling, expected",
+    [
+        ("german", "ger"),
+        ("de", "ger"),
+        ("deu", "ger"),
+        ("1", "ger"),  # bare --fetch-subs with no argument
+        ("english", "eng"),
+        ("fr", "fre"),
+    ],
+)
+def test_language_spellings_map_to_release_codes(spelling, expected):
+    assert LANG_ALIASES[spelling] == expected
+
+
+def test_unknown_language_is_not_silently_accepted():
+    assert "klingon" not in LANG_ALIASES

--- a/tests/test_subfetch_targets.py
+++ b/tests/test_subfetch_targets.py
@@ -1,0 +1,169 @@
+"""Tests for where a fetched subtitle ends up, and when none is fetched at all.
+
+The network layer (release lookup, attachment download, ffsubsync) is stubbed
+out; what is exercised is the decision logic around it -- which container gets
+a muxed track versus a sidecar file, and the guards that must return early
+without ever reaching the network.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aniworld.models.aniworld_to.dubsync import subfetch
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="ffmpeg/ffprobe not on PATH",
+)
+
+ANIWORLD_URL = (
+    "https://aniworld.to/anime/stream/sousou-no-frieren/staffel-1/episode-5"
+)
+
+SUBTITLE = """[Script Info]
+ScriptType: v4.00+
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Guten Morgen.
+"""
+
+
+class _Series:
+    """Stands in for a real series without any of its network lookups."""
+
+    title = "Frieren: Beyond Journey's End"
+    alternative_titles = ["Sousou no Frieren"]
+    mal_id = []  # empty: keeps the Jikan lookup out of the test entirely
+
+
+class _Season:
+    def __init__(self, number):
+        self.season_number = number
+
+
+class _Episode:
+    def __init__(self, url=ANIWORLD_URL, season=1, episode=5):
+        self.url = url
+        self.series = _Series()
+        self.season = _Season(season)
+        self.episode_number = episode
+
+
+@pytest.fixture
+def no_network(monkeypatch):
+    """Stub the lookup/download/align chain and record whether it was reached."""
+
+    calls = {"lookup": 0, "download": 0}
+
+    def fake_find(titles, episode_number, lang3):
+        calls["lookup"] += 1
+        return 2589985, "ass", "[Erai-raws] Sousou no Frieren - 05 [1080p][MultiSub]"
+
+    def fake_download(attachment_id, lang3, ext, dest):
+        calls["download"] += 1
+        Path(dest).write_text(SUBTITLE, encoding="utf-8")
+
+    monkeypatch.setattr(subfetch, "_find_subtitle", fake_find)
+    monkeypatch.setattr(subfetch, "_download_attachment", fake_download)
+    # ffsubsync may or may not be installed; keep the outcome deterministic.
+    monkeypatch.setattr(subfetch, "_align_subtitle", lambda video, sub, label="": sub)
+    return calls
+
+
+def _make_media(path: Path) -> Path:
+    subprocess.run(
+        ["ffmpeg", "-y", "-v", "error",
+         "-f", "lavfi", "-i", "testsrc=size=160x90:rate=10:duration=2",
+         "-f", "lavfi", "-i", "sine=frequency=440:duration=2",
+         "-c:v", "libx264", "-preset", "ultrafast", "-c:a", "aac",
+         "-metadata:s:a:0", "language=deu", str(path)],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    return path
+
+
+def _subtitle_languages(path: Path) -> list[str]:
+    probe = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "s",
+         "-show_entries", "stream_tags=language", "-of", "csv=p=0", str(path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in probe.stdout.split() if line]
+
+
+def test_mkv_gets_a_muxed_subtitle_track(tmp_path, no_network):
+    episode_file = _make_media(tmp_path / "episode.mkv")
+
+    result = subfetch.fetch_and_mux_subtitle(_Episode(), episode_file, lang="ger")
+
+    assert result == episode_file
+    assert _subtitle_languages(episode_file) == ["ger"]
+    # The downloaded subtitle is muxed in, not left lying next to the video.
+    assert not (tmp_path / "episode.ger.ass").exists()
+
+
+def test_mp4_gets_a_sidecar_instead(tmp_path, no_network):
+    """MP4 cannot carry ASS, so the subtitle is written next to the video."""
+
+    episode_file = _make_media(tmp_path / "episode.mp4")
+
+    result = subfetch.fetch_and_mux_subtitle(_Episode(), episode_file, lang="ger")
+
+    sidecar = tmp_path / "episode.ger.ass"
+    assert result == sidecar
+    assert sidecar.exists() and "Guten Morgen" in sidecar.read_text(encoding="utf-8")
+    assert _subtitle_languages(episode_file) == []
+
+
+def test_existing_subtitle_track_is_not_fetched_again(tmp_path, no_network):
+    """Re-running a completed download must be a no-op, not a second fetch."""
+
+    episode_file = _make_media(tmp_path / "episode.mkv")
+    subfetch.fetch_and_mux_subtitle(_Episode(), episode_file, lang="ger")
+    assert no_network["download"] == 1
+
+    assert subfetch.fetch_and_mux_subtitle(_Episode(), episode_file, "ger") is None
+    assert no_network["download"] == 1, "must not re-download an existing track"
+    assert _subtitle_languages(episode_file) == ["ger"]
+
+
+@pytest.mark.parametrize(
+    "episode, reason",
+    [
+        (_Episode(url="https://s.to/serie/family-guy/staffel-1/episode-1"),
+         "non-anime source has no fansub releases to search"),
+        (_Episode(season=0, episode=0), "movies carry no season/episode numbering"),
+    ],
+)
+def test_unsupported_sources_return_early(tmp_path, no_network, episode, reason):
+    episode_file = _make_media(tmp_path / "episode.mkv")
+
+    assert subfetch.fetch_and_mux_subtitle(episode, episode_file, "ger") is None
+    assert no_network["lookup"] == 0, f"must not hit the network: {reason}"
+    assert _subtitle_languages(episode_file) == []
+
+
+def test_unknown_language_is_refused(tmp_path, no_network):
+    episode_file = _make_media(tmp_path / "episode.mkv")
+
+    assert subfetch.fetch_and_mux_subtitle(_Episode(), episode_file, "klingon") is None
+    assert no_network["lookup"] == 0
+
+
+def test_a_missing_release_is_not_an_error(tmp_path, monkeypatch, no_network):
+    """No German subs exist for older shows; the download must still stand."""
+
+    monkeypatch.setattr(subfetch, "_find_subtitle", lambda *args: None)
+    episode_file = _make_media(tmp_path / "episode.mkv")
+
+    assert subfetch.fetch_and_mux_subtitle(_Episode(), episode_file, "ger") is None
+    assert _subtitle_languages(episode_file) == []
+    assert episode_file.exists(), "the episode itself must survive untouched"


### PR DESCRIPTION
Implements #238 (DubSync) and fixes #209 (multi-language sync).

In #209 you wrote:

> Maybe something like that could be possible in the future with some kind of analyzer that detects timing differences and syncs things automatically, maybe by stretching audio or with some other approach [...] feel free to investigate and prove me wrong.

That is what this is. There is no database and no manually submitted offsets — the timing is measured from the audio itself, per episode, and audio stretching is in there for the case that needs it.

It is a big PR, so here is everything you need to review it, including the parts I think are debatable.

---

## Contents

| Commit | What |
| --- | --- |
| `feat(dubsync)` | The DubSync feature from #238 + the alignment engine |
| `fix(download)` | The #209 bug: extra languages merged out of sync |
| `feat(subs)` | Optional real subtitle tracks, fetched externally |
| `feat(web)` | DubSync tab + per-download options in the series modal |
| `docs` | README + `docs/dubsync-alignment.md` |

Everything is opt-in except the #209 fix, which changes the behaviour of an existing code path (details below).

---

## 1. DubSync (#238)

Takes the dub audio from an AniWorld/SerienStream stream and muxes it into video files you already own — a Blu-ray or Nyaa rip that only carries JP/EN audio — as a secondary, language-tagged track. Your video and its original audio are stream-copied, never re-encoded.

```bash
# See what would happen, without writing to any file
aniworld https://aniworld.to/anime/stream/<series>/staffel-1 \
  --dubsync-target ~/Anime/MyShow/Season01 --dubsync-dry-run

# Writes <name>.dubsync.mkv next to each file; originals untouched
aniworld https://aniworld.to/anime/stream/<series>/staffel-1 \
  --dubsync-target ~/Anime/MyShow/Season01
```

| Flag | Effect |
| --- | --- |
| `--dubsync-target DIR` | Local folder to enrich. Enables DubSync mode. |
| `--dubsync-dry-run` | Print matches, offsets and confidences; write nothing. |
| `--dubsync-offset SECONDS` | Force a manual offset instead of detecting one. |
| `--no-dubsync-auto-align` | Disable detection (offset 0 unless `--dubsync-offset`). |
| `--dubsync-allow-resample` | Permit `atempo` drift correction (re-encodes the dub track only). |
| `--dubsync-cleanup` | Replace originals in place (temp file + atomic swap) instead of writing copies. |
| `--dubsync-recursive` | Scan the target directory recursively. |

Files are matched to episodes by filename (`Show - 01`, `S01E01`, `01v2`, …). Unmatched files are reported rather than guessed at. Files that already carry the dub language are skipped.

There is also a **DubSync tab in the Web UI**: browse to a folder, search the show, and the matching episodes are pre-selected from your filenames. Movies get a dropdown per film, since movie filenames carry no episode numbers, with the best title match pre-selected. Defaults live on the Settings page and in `ANIWORLD_DUBSYNC_*`.

### How the alignment works

Correlating the two tracks on dialogue cannot work — it is different speech in different languages. What they share is the **music and sound-effects bed**: a door slam or a musical sting lands at the same story moment in every language version. So both tracks are reduced to 100 Hz onset envelopes (10 ms frames → log RMS → half-wave-rectified difference), FFT-cross-correlated, and the peak is scored as a **z-score against the rest of the search range**.

That confidence score is the part that matters for review, because it is what stops the feature from guessing:

* a genuine match is a needle — z ≫ 10, often in the hundreds;
* two unrelated tracks give a mushy landscape whose best bump is z ≈ 3–5.

Below **z = 8** the detection is not trusted: the episode falls back to offset 0 and is flagged in the report for manual checking. It never silently applies a number it does not believe.

`docs/dubsync-alignment.md` has the full write-up, including the tempo scan below.

Cost is about 2 s per episode — everything after decoding runs on envelopes, not raw audio. Only **numpy** is needed (`rfft`/`irfft`); no scipy, no fingerprinting library.

---

## 2. The #209 bug: extra languages merged out of sync

`download()` had two merge sites that appended a second-language stream with a plain `-c copy` concat and no timing correction. Since the encodes come from different hosters and rarely start at the same instant, the added track played late — exactly as reported.

Both sites now measure the offset with the aligner above and apply it via `-itsoffset`. Everything lands in **one file**: an extra dub becomes another audio track, and a hardsubbed "Sub" variant (which brings its own video) is appended as a video+audio pair shifted as a single unit. Appended streams get their default disposition cleared, so players keep the original primary track.

### The part WimWamWom ran into

He concluded it was *"pretty hard, if not impossible, to get a universal solution [...] especially not when there are major differences in cuts or scenes"* — and he was right about why the naive approach fails. A constant offset is the wrong model for two of the three cases:

| Case | Handled? |
| --- | --- |
| Constant offset (different pre-roll/trim) | Yes — `-itsoffset`, lossless |
| **Linear drift** (PAL 25 fps vs film 23.976, ~4.3 % apart) | Yes — detected by tempo scan, corrected with `atempo` |
| Genuinely different cuts/scenes | **No** — and it refuses rather than guessing (confidence gate) |

The middle row is the one that bites on German content, and it is not a corner case — it is the norm for TV dubs. His own Family Guy example is exactly it. Measured on `s.to` Family Guy S01E01 German+English:

```
[DUBSYNC] global offset +95.577s (confidence z=5.0)      <- noise, correctly distrusted
[DUBSYNC] tempo scan: x0.959040 z=19.5 (identity z=5.0)  <- 23.976/25, the real answer
```

The constant-offset peak was meaningless; only the *speed ratio* was real. So drift is checked first, and when found the added track is **retimed** rather than shifted, then the small residual offset is applied. Result on that episode: retimed ×1.042709, residual −1.89 s, track length within 5 s of the reference over 22 minutes (it was 50 s out before).

I had this wrong at first in a way worth flagging, since it is a trap in the API: `detect_offset` overwrites `result.confidence` with the *drift* confidence while leaving `result.offset` at the identity-tempo value, so reading the two together claims high confidence in a number measured at noise level. That is how an early version put a track 95 s late. `has_drift` is now checked before the offset is read at all, and there is a regression test for it.

### Behaviour change to be aware of

This is the one part of the PR that is on by default, because it fixes a bug in an existing path. Two consequences:

* **Retiming re-encodes the added track** (AAC — the source is an already-lossy stream rip, and a lossless track would dwarf the video). Only the freshly added track is ever re-encoded; existing streams are stream-copied. `--no-merge-resample` disables it, `--no-merge-align` disables alignment entirely, and both have env equivalents.
* **"Sub" variants no longer become separate files.** They merge into the same file as a second video track. If you would rather keep the old one-file-per-language layout, `{language}` in the naming template still does that.

---

## 3. Optional: real subtitle tracks (`--fetch-subs`)

You noted in #209 that burned-in subs are why sub variants arrive as extra video streams. This is a way around that for anime.

The hosters only serve hardsubbed video, so a togglable subtitle track cannot come from them — but Erai-raws MultiSub releases carry the official Crunchyroll subtitles, and **Animetosho extracts each subtitle stream and serves it individually** over a JSON API with no key and no account.

```bash
aniworld -l "German Dub" --fetch-subs <episode-url>      # German (default)
aniworld -l "German Dub" --fetch-subs eng <episode-url>  # or eng/fre/spa/ita/por/rus/ara
```

After a download the episode's season is resolved to its MyAnimeList entry (the mapping AniSkip already maintains) to get the romaji title scene releases are named after, the matching release is looked up, and the subtitle is muxed in as a non-default, language-tagged track — or written as a sidecar file for containers that cannot hold ASS, such as MP4.

Also available per-download in the Web UI, and via `ANIWORLD_FETCH_SUBS=ger` for queue downloads.

Two implementation notes:

* **Release matching uses bidirectional token containment**, not a symmetric similarity score. Sequel seasons share nearly all of their title words, so a plain score cheerfully returns season 1's subtitles for a season 2 episode. Tested both directions.
* **Jikan is flaky** (regular 504s). Its search retries once, and the series page's own `data-alternativeTitles` provides the romaji name as a fallback. Without either, one failed lookup silently disabled the whole feature — that is how Frieren S2 came back empty during testing.

**Scope, honestly:** anime only, and roughly 2020+ for German — older seasons predate Erai-raws' German subs. Bunny Girl Senpai (2018) finds English but no German. A miss is logged and the download completes normally; it can never fail a download. If `ffsubsync` is installed it is used to align the subtitle to your file, otherwise that is logged and the release's timing is kept.

---

## 4. Web UI

* **DubSync tab** as described above.
* **Series modal** gains checkboxes for the other languages a title actually has, plus a subtitle-track option on AniWorld. Each has a plain-language tooltip describing what ends up in the file. Both rows hide themselves where they do not apply.
* Per-download choices travel with the queue item in a **new `options` column** (added by the existing migration pattern in `db.py`) rather than through global settings, so two queued jobs can want different things. The worker applies them per job and restores the server defaults afterwards.
* A failing extra language is recorded in the job's errors but no longer marks an otherwise successful download as failed.
* All new strings are in the **en and de** translation files.
* Drive-by fix: `.toast.show` had no CSS rule anywhere, so the Web UI's toast notifications had never actually been visible.

---

## 5. Testing

**40 automated tests** (`pytest`), up from 6, all passing in under 10 s. No network access; media is synthesised with ffmpeg and the subtitle fetcher's network layer is stubbed.

* `test_dubsync_align.py` — impulse-bed signals with known shifts, PAL drift, and uncorrelated noise; asserts recovered offsets/tempi and that noise stays below the confidence threshold.
* `test_multilang_merge.py` — the #209 bug end to end: a deliberately delayed second language must come back aligned, tagged and non-default, in one file. Includes the PAL-drift case that must be retimed rather than shifted, and the opt-out flags.
* `test_subfetch_matching.py` — release matching, including that sequel seasons are rejected in both directions.
* `test_subfetch_targets.py` — muxed track for MKV vs sidecar for MP4, no re-fetch when a track already exists, and that unsupported sources exit before touching the network.

**Verified live** (Linux, VOE) beyond the suite: the #209 repro in both orders on `s.to` Family Guy S01E01 with the result checked by ear; German Dub + German Sub on AniWorld; `--fetch-subs` on Frieren S2E1 (German subtitle muxed and selectable) and on Bunny Girl Senpai (correctly finds nothing, download unaffected); a Web UI queue download with every option ticked; re-downloading a complete episode (skips, file byte-identical, no temp files left); and `--no-merge-align` (aligner never loads).

Not tested on Windows or macOS. Nothing in the changed code is platform-specific — it is ffmpeg invocations and `pathlib` — but I would rather say so than imply coverage I do not have.

---

## 6. Known limitations

* **Media servers ignore the second video track.** You called this in #209 and it still holds: Jellyfin plays the first video track only, so a hardsubbed "Sub" variant is not reachable there. Confirmed again during testing. mpv and VLC switch fine. Documented in the README with the two workarounds (`{language}` naming, or `--fetch-subs`). Extra *audio* tracks are picked up everywhere.
* **Different cuts/scenes are not solvable this way** and are not attempted. The confidence gate detects that case and declines.
* **Subtitle fetching depends on a third party** (Animetosho + Erai-raws release naming). If either changes, the feature degrades to "no subtitle found" and logs it — it cannot break a download.
* **numpy becomes a hard dependency.** See below.

---

## 7. Things you may want changed

Rather than have you find these in review:

1. **numpy as a hard dependency.** It is only needed for `rfft`/`irfft` in the aligner. If you would rather not add it for every user, I can move it behind an extra (`aniworld[dubsync]`) with a lazy import and a clear error when the feature is used without it. Say the word and I will push that.
2. **The subtitle fetcher pulls from the fansub scene** (Animetosho/Erai-raws). It is opt-in and off by default, but it is a different kind of dependency from a stream hoster, and it is entirely reasonable if you would rather it not live in this repo. It is a self-contained commit and can be dropped without touching the rest.
3. **Retiming defaults to on.** I chose that because an added track that cannot be synced is useless, and only the new track is re-encoded — but it is a re-encode happening by default, so if you would prefer opt-in, it is a one-line default flip.
4. **Commits are grouped by feature** rather than mirroring how they were written, so each one is reviewable on its own. Happy to squash or split further.

Not included: no CI changes, no version bump, no changes to any existing provider or extractor.
