### PR TITLE
fix(naming): preserve apostrophes and other HTML entities in series titles

### DIFF
--- a/src/aniworld/models/burningseries/series.py
+++ b/src/aniworld/models/burningseries/series.py
@@ -625,7 +625,8 @@ class BurningSeriesSeries:
                 title = re.sub(r"<[^>]+>", " ", m.group(1))
                 # The heading also carries the season nav ("… Staffel 1"); drop it.
                 title = re.split(r"\bStaffel\b", title, flags=re.IGNORECASE)[0]
-                title = re.sub(r"\s+", " ", title).strip()
+                # Unescape only after tag stripping
+                title = re.sub(r"\s+", " ", html_module.unescape(title)).strip()
             else:
                 title = (self.slug or "").replace("-", " ").title()
             self.__title = title or self.slug

--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import threading
 import time
+from html import unescape
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -53,6 +54,34 @@ FORBIDDEN_CHARS = re.compile(r'[<>:"/\\|?*]')
 def clean_title(title: str) -> str:
     """Clean a string to make it safe for use as a filename."""
     return FORBIDDEN_CHARS.sub("", title).strip()
+
+
+def _adopt_escaped_path(parent: Path, target: str) -> None:
+    """Rename a leftover "It&#039;s …" sibling in `parent` to `target`."""
+    if not parent.is_dir() or (parent / target).exists():
+        return
+
+    for entry in parent.iterdir():
+        decoded = unescape(entry.name)
+        if decoded != entry.name and clean_title(decoded) == target:
+            entry.rename(parent / target)
+            logger.info(f"[RENAMED] {entry.name} -> {target}")
+            return
+
+
+def migrate_escaped_paths(self) -> None:
+    """Adopt folders/files written before series titles were unescaped."""
+    for path in (
+        getattr(self, "_base_folder", None),
+        getattr(self, "_folder_path", None),
+        getattr(self, "_episode_path", None),
+    ):
+        if path is None:
+            continue
+        try:
+            _adopt_escaped_path(Path(path).parent, Path(path).name)
+        except OSError as exc:
+            logger.debug(f"could not adopt escaped path for {path}: {exc}")
 
 
 def _quote_windows_cmd_arg(arg) -> str:
@@ -802,6 +831,8 @@ def download_hanime(self):
         manager = DependencyManager()
         manager.fetch_binary("ffmpeg")
 
+    migrate_escaped_paths(self)
+
     if self._episode_path.exists():
         logger.debug(f"[SKIPPED] {self._file_name} (already downloaded)")
         return
@@ -1043,6 +1074,8 @@ def download(self):
     if platform.system() == "Windows":
         manager = DependencyManager()
         manager.fetch_binary("ffmpeg")
+
+    migrate_escaped_paths(self)
 
     max_retries = 3
     provider_order = _get_provider_attempt_order(self)

--- a/src/aniworld/models/filmpalast_to/episode.py
+++ b/src/aniworld/models/filmpalast_to/episode.py
@@ -1,5 +1,6 @@
 import os
 import re
+from html import unescape
 from pathlib import Path
 
 try:
@@ -415,7 +416,8 @@ class FilmPalastEpisode:
     def __extract_title_de(self):
         match = re.search(r'<em itemprop="name">(.*?)</em>', self._html)
         if match:
-            self.__title_de = match.group(1).strip()
+            # Escaped in the page source, before the title becomes a file name
+            self.__title_de = unescape(match.group(1)).strip()
 
     def __extract_user_watched(self):
         match = re.search(r"<strong>(\d+)</strong> Nutzer", self._html)

--- a/src/aniworld/models/kinox/series.py
+++ b/src/aniworld/models/kinox/series.py
@@ -573,6 +573,8 @@ class KinoxSeries:
                 re.IGNORECASE,
             )
             title = m.group(1) if m else (self.slug or "").replace("_", " ")
+            # The meta content is HTML-escaped 
+            title = html_lib.unescape(title)
             # og:title reads "Title (Year) Stream online anschauen …" — trim it.
             title = re.split(r"\bStream\b", title, flags=re.IGNORECASE)[0]
             title = re.sub(r"\s*\(\d{4}\)\s*$", "", title).strip()

--- a/src/aniworld/models/megakino/series.py
+++ b/src/aniworld/models/megakino/series.py
@@ -1,6 +1,7 @@
 import os
 import re
 from functools import lru_cache
+from html import unescape
 from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
@@ -452,7 +453,8 @@ class MegaKinoEpisode:
             r'<meta\s+itemprop=["\']name["\']\s+content=["\']([^"\']+)["\']',
             self._html,
         )
-        self.__title = match.group(1).strip() if match else None
+        # The meta content is HTML-escaped
+        self.__title = unescape(match.group(1)).strip() if match else None
 
     def __extract_title_cleaned(self):
         self.__title_cleaned = clean_title(self.title) if self.title else None
@@ -462,7 +464,7 @@ class MegaKinoEpisode:
             r'<div\s+class=["\']pmovie__original-title["\']\s+itemprop=["\']alternativeHeadline["\']\s*>([^<]*)<',
             self._html,
         )
-        self.__original_title = match.group(1).strip() if match else None
+        self.__original_title = unescape(match.group(1)).strip() if match else None
 
     def __extract_description(self):
         match = re.search(

--- a/src/aniworld/models/s_to/series.py
+++ b/src/aniworld/models/s_to/series.py
@@ -1,4 +1,5 @@
 import re
+from html import unescape
 from urllib.parse import urljoin, urlparse
 
 from ...config import SERIENSTREAM_SERIES_PATTERN, logger
@@ -185,7 +186,10 @@ class SerienstreamSeries:
         match = pattern.search(self._html)
 
         if match:
-            title = match.group(1).strip()
+            # The heading is HTML-escaped, so an apostrophe arrives as "&#039;"
+            # ("It&#039;s Always Sunny in Philadelphia") and would end
+            # up verbatim in folder and file names.
+            title = unescape(match.group(1)).strip()
             return title
 
         return None


### PR DESCRIPTION
Closes #279 

Series titles are read straight from the page markup, where they arrive
HTML-escaped (`<h1>It&#039;s Always Sunny in Philadelphia</h1>`). `clean_title`
only strips forbidden characters, so the entity ended up in folder and
file names. aniworld.to and hanime.tv already decoded, which is why only some
series broke.

- Decode with the existing `html.unescape` at the scrape site in the five
  providers missing it: serienstream.to, kinox, burning-series, megakino,
  filmpalast.to. Not in `clean_title`, since the providers that already decode
  would decode twice 
- `migrate_escaped_paths` adopts what the bug already wrote to disk: at the start
  of the shared `download()`, before the skip check, it renames base folder,
  season folder and episode file. Otherwise those episodes no longer match and
  get fetched a second time. Matching decodes the existing names instead of
  re-escaping the new one, since sites differ (`&#039;`, `&apos;`, `&rsquo;`);
  a candidate must contain an entity, so unrelated folders stay untouched

