### PR TITLE
queue item stuck showing "Cancelling..." indefinitely

### DIFF
--- a/src/aniworld/web/static/queue.js
+++ b/src/aniworld/web/static/queue.js
@@ -152,7 +152,7 @@ function renderQueue(items) {
       isRunning || (item.status === "cancelled" && item.current_url);
     const cls = isActive ? "queue-item queue-item-active" : "queue-item";
 
-    const isCancelling = item.status === "cancelled" && item.current_url;
+    const isCancelling = item.status === "cancelling";
 
     let statusBadge = "";
     if (item.status === "running")


### PR DESCRIPTION
The isCancelling check in queue.js compared item.status === "cancelled" && item.current_url, but current_url gets cleared once cancellation completes — so the condition never matched and the UI stayed on "Cancelling..." forever even after the item was actually cancelled. Fixed by checking item.status === "cancelling" directly.