### PR TITLE
feat: genre grouping, correct movie detection, and watched-episode tracking in library view

### DIFF
--- a/src/aniworld/web/app.py
+++ b/src/aniworld/web/app.py
@@ -42,6 +42,10 @@ from ..search import (
 from ..search import query as aniworld_query
 from .db import (
     add_autosync_job,
+    get_genre_lookup,
+    get_watched_set,
+    set_watched,
+    init_watched_db,
     add_custom_path,
     update_custom_path,
     add_to_queue,
@@ -1169,6 +1173,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
     init_custom_paths_db()
     init_autosync_db()
     init_planned_db()
+    init_watched_db()
 
     # Wire up captcha hooks so the Playwright module can signal the Web UI
     from ..playwright import captcha as _captcha_mod
@@ -1866,6 +1871,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                 )
 
         custom_path_id = data.get("custom_path_id")
+        genre = (data.get("genre") or "").strip()
 
         queue_id = add_to_queue(
             title,
@@ -1875,6 +1881,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             provider,
             username,
             custom_path_id=custom_path_id,
+            genre=genre or None,
         )
         return jsonify({"queue_id": queue_id})
 
@@ -2683,7 +2690,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                 cp_base = Path.home() / cp_base
             scan_targets.append((cp["name"], cp["id"], cp_base))
 
-        def _scan_base(base):
+        def _scan_base(base, cp_id):
             """Scan a single base directory and return list of title dicts."""
             lang_folder_set = set(lang_folders)
             titles = {}
@@ -2693,6 +2700,9 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                 folders = list(base.iterdir())
             except (PermissionError, OSError):
                 return []
+
+            genre_lookup = get_genre_lookup()
+            watched_set = get_watched_set(cp_id)
 
             for folder in folders:
                 if not folder.is_dir():
@@ -2707,11 +2717,15 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                     if not f.is_file() or f.name.startswith(".temp_"):
                         continue
                     m = ep_re.search(f.name)
-                    if not m:
-                        continue
-                    snum = int(m.group(1))
-                    enum = int(m.group(2))
                     is_video = f.suffix.lower() in video_exts
+                    if m:
+                        snum = int(m.group(1))
+                        enum = int(m.group(2))
+                    elif is_video:
+                        snum = "movie"
+                        enum = len(entry["seasons"].get("movie", [])) + 1
+                    else:
+                        continue
                     try:
                         fsize = f.stat().st_size
                     except OSError:
@@ -2723,12 +2737,14 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                         e["episode"] == enum and e["file"] == f.name
                         for e in entry["seasons"][skey]
                     ):
+                        is_watched = (name, skey, enum, f.name) in watched_set
                         entry["seasons"][skey].append(
                             {
                                 "episode": enum,
                                 "file": f.name,
                                 "size": fsize,
                                 "is_video": is_video,
+                                "watched": is_watched,
                             }
                         )
                         entry["total_size"] += fsize
@@ -2743,12 +2759,28 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                 )
                 for skey in entry["seasons"]:
                     entry["seasons"][skey].sort(key=lambda e: e["episode"])
+
+                media_type = (
+                    "movie"
+                    if set(entry["seasons"].keys()) == {"movie"}
+                    else "series"
+                )
+
+                folder_lower = entry["folder"].strip().lower()
+                genre = "Sonstiges"
+                for title_key, title_genre in genre_lookup.items():
+                    if folder_lower.startswith(title_key) or title_key.startswith(folder_lower):
+                        genre = title_genre
+                        break
+
                 result.append(
                     {
                         "folder": entry["folder"],
                         "seasons": entry["seasons"],
                         "total_episodes": total_eps,
                         "total_size": entry["total_size"],
+                        "media_type": media_type,
+                        "genre": genre,
                     }
                 )
             return result
@@ -2758,7 +2790,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
             if lang_sep:
                 loc_lang_folders = []
                 for lf in lang_folders:
-                    lf_titles = _scan_base(base_path / lf)
+                    lf_titles = _scan_base(base_path / lf, cp_id)
                     if lf_titles:
                         loc_lang_folders.append(
                             {
@@ -2776,7 +2808,7 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
                         }
                     )
             else:
-                loc_titles = _scan_base(base_path)
+                loc_titles = _scan_base(base_path, cp_id)
                 if loc_titles:
                     locations.append(
                         {
@@ -2890,6 +2922,24 @@ def create_app(auth_enabled=False, sso_enabled=False, force_sso=False):
         if deleted == 0:
             return jsonify({"error": "Nothing found to delete"}), 404
         return jsonify({"ok": True, "deleted": deleted})
+
+    @app.route("/api/library/watched", methods=["POST"])
+    def api_library_watched():
+        data = request.get_json(silent=True) or {}
+        folder = data.get("folder", "")
+        season = data.get("season")
+        episode = data.get("episode")
+        file = data.get("file", "")
+        watched = bool(data.get("watched"))
+        custom_path_id = data.get("custom_path_id")
+
+        if not folder or season is None or episode is None or not file:
+            return jsonify(
+                {"error": "folder, season, episode and file are required"}
+            ), 400
+
+        set_watched(custom_path_id, folder, season, episode, file, watched)
+        return jsonify({"ok": True, "watched": watched})
 
     if auth_enabled:
         from .auth import admin_required

--- a/src/aniworld/web/db.py
+++ b/src/aniworld/web/db.py
@@ -330,6 +330,11 @@ def init_queue_db():
             conn.execute("ALTER TABLE download_queue ADD COLUMN discord_user_id TEXT")
         except Exception:
             pass  # column already exists
+        # Add genre column so the library view can group by genre
+        try:
+            conn.execute("ALTER TABLE download_queue ADD COLUMN genre TEXT")
+        except Exception:
+            pass  # column already exists
         conn.commit()
     finally:
         conn.close()
@@ -345,14 +350,15 @@ def add_to_queue(
     custom_path_id=None,
     source="manual",
     discord_user_id=None,
+    genre=None,
 ):
     import json
 
     conn = get_db()
     try:
         cur = conn.execute(
-            "INSERT INTO download_queue (title, series_url, episodes, total_episodes, language, provider, username, custom_path_id, source, discord_user_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO download_queue (title, series_url, episodes, total_episodes, language, provider, username, custom_path_id, source, discord_user_id, genre) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 title,
                 series_url,
@@ -364,6 +370,7 @@ def add_to_queue(
                 custom_path_id,
                 source,
                 discord_user_id,
+                genre,
             ),
         )
         row_id = cur.lastrowid
@@ -671,6 +678,21 @@ def clear_completed():
         conn.close()
 
 
+def get_genre_lookup():
+    """Return {title_lower: genre} from the most recent queue entry per title
+    that actually has a genre set. Used by the library scan to tag folders."""
+    conn = get_db()
+    try:
+        rows = conn.execute(
+            "SELECT title, genre FROM download_queue "
+            "WHERE genre IS NOT NULL AND genre != '' "
+            "ORDER BY id ASC"
+        ).fetchall()
+        return {r["title"].strip().lower(): r["genre"] for r in rows if r["title"]}
+    finally:
+        conn.close()
+
+
 # ===== Custom Download Paths =====
 
 _CREATE_CUSTOM_PATHS_TABLE = """\
@@ -766,6 +788,70 @@ def get_custom_path_by_id(path_id):
             (path_id,),
         ).fetchone()
         return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+# ===== Watched Episodes =====
+
+_CREATE_WATCHED_TABLE = """\
+CREATE TABLE IF NOT EXISTS watched_episodes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    custom_path_id INTEGER NOT NULL DEFAULT 0,
+    folder TEXT NOT NULL,
+    season TEXT NOT NULL,
+    episode INTEGER NOT NULL,
+    file TEXT NOT NULL,
+    watched_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(custom_path_id, folder, season, episode, file)
+);
+"""
+
+
+def init_watched_db():
+    ANIWORLD_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    conn = get_db()
+    try:
+        conn.execute(_CREATE_WATCHED_TABLE)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_watched_set(custom_path_id=None):
+    """Return {(folder, season, episode, file)} for one location (custom_path_id
+    None/0 = default download path)."""
+    cp_key = custom_path_id or 0
+    conn = get_db()
+    try:
+        rows = conn.execute(
+            "SELECT folder, season, episode, file FROM watched_episodes "
+            "WHERE custom_path_id = ?",
+            (cp_key,),
+        ).fetchall()
+        return {(r["folder"], r["season"], r["episode"], r["file"]) for r in rows}
+    finally:
+        conn.close()
+
+
+def set_watched(custom_path_id, folder, season, episode, file, watched):
+    cp_key = custom_path_id or 0
+    conn = get_db()
+    try:
+        if watched:
+            conn.execute(
+                "INSERT OR IGNORE INTO watched_episodes "
+                "(custom_path_id, folder, season, episode, file) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (cp_key, folder, str(season), int(episode), file),
+            )
+        else:
+            conn.execute(
+                "DELETE FROM watched_episodes WHERE custom_path_id = ? "
+                "AND folder = ? AND season = ? AND episode = ? AND file = ?",
+                (cp_key, folder, str(season), int(episode), file),
+            )
+        conn.commit()
     finally:
         conn.close()
 

--- a/src/aniworld/web/static/library.js
+++ b/src/aniworld/web/static/library.js
@@ -134,14 +134,69 @@ async function loadLibrary() {
     renderLibrary(libraryLocations);
     restoreExpandedState(prevState);
   } catch (e) {
-    list.innerHTML = '<div class="library-empty">Failed to load library</div>';
+    console.error('loadLibrary failed:', e);
+    list.innerHTML = '<div class="library-empty">Failed to load library: ' + e.message + '</div>';
   }
+}
+
+// --- Watched status ---
+
+var WATCHED_BG = "rgba(76, 175, 80, 0.18)";
+
+async function setWatchedStatus(locIndex, folder, skey, episode, file, watched) {
+  var loc = libraryLocations[locIndex];
+  var body = {
+    folder: folder,
+    season: skey,
+    episode: episode,
+    file: file,
+    watched: watched,
+    custom_path_id: loc ? loc.custom_path_id : null,
+  };
+  try {
+    var resp = await fetch("/api/library/watched", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    var data = await resp.json();
+    return !data.error;
+  } catch (e) {
+    return false;
+  }
+}
+
+function applyWatchedStyle(epId, watched) {
+  var el = document.getElementById(epId);
+  if (!el) return;
+  el.dataset.watched = watched ? "1" : "0";
+  el.style.backgroundColor = watched ? WATCHED_BG : "";
+  var btn = el.querySelector(".library-watched-toggle");
+  if (btn) btn.textContent = watched ? "\u2713" : "\u25CB";
+}
+
+function markWatchedOnClick(epId, locIndex, folder, skey, episode, file) {
+  // Fire-and-forget: don't block the new-tab navigation
+  var el = document.getElementById(epId);
+  if (el && el.dataset.watched === "1") return; // already watched
+  setWatchedStatus(locIndex, folder, skey, episode, file, true).then(function (ok) {
+    if (ok) applyWatchedStyle(epId, true);
+  });
+}
+
+async function toggleWatched(epId, locIndex, folder, skey, episode, file) {
+  var el = document.getElementById(epId);
+  var currentlyWatched = el && el.dataset.watched === "1";
+  var next = !currentlyWatched;
+  var ok = await setWatchedStatus(locIndex, folder, skey, episode, file, next);
+  if (ok) applyWatchedStyle(epId, next);
 }
 
 // --- Render helpers ---
 
-function renderTitles(html, titles, idPrefix, padLeft, locIndex, langFolder) {
-  titles.forEach(function (title, ti) {
+function renderTitles(html, titles, idPrefix, padLeft, locIndex, langFolder, indices) {
+  titles.forEach(function (title, i) {
+    var ti = (indices && indices[i] !== undefined) ? indices[i] : i;
     var globalTi = idPrefix + "T" + ti;
     var seasonKeys = Object.keys(title.seasons).sort(function (a, b) {
       return parseInt(a) - parseInt(b);
@@ -216,7 +271,8 @@ function renderTitles(html, titles, idPrefix, padLeft, locIndex, langFolder) {
       var seasonEpCount = eps.filter(function (e) {
         return e.is_video !== false;
       }).length;
-      html.push("<span>Season " + skey + " (" + seasonEpCount + " ep)</span>");
+      var seasonLabel = (skey === "movie") ? "Filme" : ("Season " + skey);
+      html.push("<span>" + seasonLabel + " (" + seasonEpCount + " ep)</span>");
       html.push("</div>");
       html.push('<div class="library-season-right">');
       html.push(
@@ -243,20 +299,39 @@ function renderTitles(html, titles, idPrefix, padLeft, locIndex, langFolder) {
       html.push("</div>");
 
       html.push('<div class="library-season-body" id="' + sid + 'Body">');
-      eps.forEach(function (ep) {
+      eps.forEach(function (ep, epi) {
+        var epId = sid + "_E" + epi;
+        var isWatched = !!ep.watched;
+        var bgStyle = isWatched ? "background-color:" + WATCHED_BG + ";" : "";
         html.push(
-          '<div class="library-episode" style="padding-left:' + epPad + 'px">',
+          '<div class="library-episode" id="' + epId + '" data-watched="' +
+          (isWatched ? "1" : "0") +
+          '" style="padding-left:' + epPad + 'px;' + bgStyle + '">',
         );
         html.push(
           '<span class="library-ep-num">E' +
           String(ep.episode).padStart(3, "0") +
           "</span>",
         );
+        var epUrl = (skey === "movie")
+          ? "/files/" + encodeURIComponent(title.folder) + "/" + encodeURIComponent(ep.file)
+          : "/files/" + encodeURIComponent(title.folder) + "/" +
+            encodeURIComponent("Season " + String(skey).padStart(2, "0")) + "/" +
+            encodeURIComponent(ep.file);
+        var watchArgs =
+          "'" + epId + "'," + locIndex + ",'" + escLib(title.folder) + "','" +
+          skey + "'," + ep.episode + ",'" + escLib(ep.file) + "'";
         html.push(
-          '<span class="library-ep-file">' + escLib(ep.file) + "</span>",
+          '<a class="library-ep-file" href="' + epUrl + '" target="_blank" onclick="markWatchedOnClick(' +
+          watchArgs + ')">' + escLib(ep.file) + "</a>",
         );
         html.push(
           '<span class="library-ep-size">' + formatSize(ep.size) + "</span>",
+        );
+        html.push(
+          '<button class="library-watched-toggle" onclick="event.stopPropagation();toggleWatched(' +
+          watchArgs + ')" title="Als gesehen/ungesehen markieren">' +
+          (isWatched ? "\u2713" : "\u25CB") + "</button>",
         );
         if (libraryCanDelete) {
           var delArgs =
@@ -392,8 +467,109 @@ function renderLibrary(locations) {
         html.push("</div>");
       });
     } else if (loc.titles) {
-      // Lang sep OFF: Location > Title > Season > Episode
-      renderTitles(html, loc.titles, "L" + li, 32, li, null);
+      // Location > MediaType (Filme/Serien) > [Alle | Genre] > Title > (Season >) Episode
+      var mediaGroups = { series: [], movie: [] };
+      loc.titles.forEach(function (t, ti) {
+        var mt = t.media_type === "movie" ? "movie" : "series";
+        mediaGroups[mt].push({ title: t, idx: ti });
+      });
+      ["series", "movie"].forEach(function (mtKey) {
+        var entries = mediaGroups[mtKey];
+        var mtLabel = mtKey === "movie" ? "Filme" : "Serien";
+        var mtId = "L" + li + "MT" + mtKey;
+        var mtEps = 0, mtSize = 0;
+        entries.forEach(function (e) {
+          mtEps += e.title.total_episodes;
+          mtSize += e.title.total_size;
+        });
+        html.push('<div class="library-title-section">');
+        html.push(
+          '<div class="library-season-header" onclick="toggleLibrarySeason(\'' +
+          mtId + '\')" style="padding-left:32px">'
+        );
+        html.push('<div class="library-season-left">');
+        html.push('<span class="library-arrow" id="' + mtId + 'Arrow">&#9654;</span>');
+        html.push('<span style="font-weight:600;color:#fff">' + mtLabel + "</span>");
+        html.push("</div>");
+        html.push('<div class="library-season-right">');
+        html.push('<span class="library-meta">' + mtEps + " ep</span>");
+        html.push('<span class="library-meta library-meta-size">' + formatSize(mtSize) + "</span>");
+        html.push("</div>");
+        html.push("</div>");
+        html.push('<div class="library-title-body" id="' + mtId + 'Body">');
+
+        // "Alle" tab: every title in this media-type group, ungrouped by genre
+        if (entries.length) {
+          var allId = mtId + "GAll";
+          var allEps = 0, allSize = 0;
+          entries.forEach(function (e) {
+            allEps += e.title.total_episodes;
+            allSize += e.title.total_size;
+          });
+          html.push('<div class="library-title-section">');
+          html.push(
+            '<div class="library-season-header" onclick="toggleLibrarySeason(\'' +
+            allId + '\')" style="padding-left:48px">'
+          );
+          html.push('<div class="library-season-left">');
+          html.push('<span class="library-arrow" id="' + allId + 'Arrow">&#9654;</span>');
+          html.push('<span style="font-weight:500">Alle</span>');
+          html.push("</div>");
+          html.push('<div class="library-season-right">');
+          html.push('<span class="library-meta">' + allEps + " ep</span>");
+          html.push('<span class="library-meta library-meta-size">' + formatSize(allSize) + "</span>");
+          html.push("</div>");
+          html.push("</div>");
+          html.push('<div class="library-title-body" id="' + allId + 'Body">');
+          var allTitles = entries.map(function (e) { return e.title; });
+          var allIndices = entries.map(function (e) { return e.idx; });
+          renderTitles(html, allTitles, allId, 64, li, null, allIndices);
+          html.push("</div>");
+          html.push("</div>");
+        }
+
+        var genreGroups = {};
+        entries.forEach(function (e) {
+          var genreStr = e.title.genre || "Sonstiges";
+          var genreList = genreStr.split(",").map(function (g) { return g.trim(); }).filter(Boolean);
+          genreList.forEach(function (g) {
+            if (!genreGroups[g]) genreGroups[g] = [];
+            genreGroups[g].push(e);
+          });
+        });
+        Object.keys(genreGroups).sort().forEach(function (genreName, gi) {
+          var gEntries = genreGroups[genreName];
+          var gId = mtId + "G" + gi;
+          var gEps = 0, gSize = 0;
+          gEntries.forEach(function (e) {
+            gEps += e.title.total_episodes;
+            gSize += e.title.total_size;
+          });
+          html.push('<div class="library-title-section">');
+          html.push(
+            '<div class="library-season-header" onclick="toggleLibrarySeason(\'' +
+            gId + '\')" style="padding-left:48px">'
+          );
+          html.push('<div class="library-season-left">');
+          html.push('<span class="library-arrow" id="' + gId + 'Arrow">&#9654;</span>');
+          html.push('<span style="font-weight:500">' + escLib(genreName) + "</span>");
+          html.push("</div>");
+          html.push('<div class="library-season-right">');
+          html.push('<span class="library-meta">' + gEps + " ep</span>");
+          html.push('<span class="library-meta library-meta-size">' + formatSize(gSize) + "</span>");
+          html.push("</div>");
+          html.push("</div>");
+          html.push('<div class="library-title-body" id="' + gId + 'Body">');
+          var gTitles = gEntries.map(function (e) { return e.title; });
+          var gIndices = gEntries.map(function (e) { return e.idx; });
+          renderTitles(html, gTitles, gId, 64, li, null, gIndices);
+          html.push("</div>");
+          html.push("</div>");
+        });
+
+        html.push("</div>");
+        html.push("</div>");
+      });
     }
 
     html.push("</div>");


### PR DESCRIPTION
This PR implements three related improvements to the library view:

Movie detection fix — files without an SxxExx pattern are now correctly classified as movies instead of being miscounted as Season 0.

Genre grouping — new genre column on download_queue, looked up by title and used to tag library folders (falls back to "Sonstiges"). Library view groups by Series/Movies → Genre → Title, with an "Alle" tab per media type showing everything ungrouped.

Watched tracking — new watched_episodes table + POST /api/library/watched endpoint. Episodes are marked watched automatically when opened (new tab) and can be toggled manually; watched rows get a light green background.

Open to feedback on approach, naming, or scope.