### PR TITLE
fix: Series.download/watch/syncplay abort whole batch on single episode failure

### DIFF
--- a/src/aniworld/models/aniworld_to/series.py
+++ b/src/aniworld/models/aniworld_to/series.py
@@ -717,16 +717,16 @@ class AniworldSeries:
     # -----------------------------
 
     def download(self):
+        # One failed episode must not abandon the rest of the batch.
         for season in self.seasons:
-            for episode in season.episodes:
-                episode.download()
+            season.download()
 
     def watch(self):
+        # One failed episode must not abandon the rest of the batch.
         for season in self.seasons:
-            for episode in season.episodes:
-                episode.watch()
+            season.watch()
 
     def syncplay(self):
+        # One failed episode must not abandon the rest of the batch.
         for season in self.seasons:
-            for episode in season.episodes:
-                episode.syncplay()
+            season.syncplay()

--- a/src/aniworld/models/hanime_tv/series.py
+++ b/src/aniworld/models/hanime_tv/series.py
@@ -536,17 +536,16 @@ class HanimeTVSeries:
     # -----------------------------
 
     def download(self):
-        print(self.to_dict())
+        # One failed episode must not abandon the rest of the batch.
         for season in self.seasons:
-            for episode in season.episodes:
-                episode.download()
+            season.download()
 
     def watch(self):
+        # One failed episode must not abandon the rest of the batch.
         for season in self.seasons:
-            for episode in season.episodes:
-                episode.watch()
+            season.watch()
 
     def syncplay(self):
+        # One failed episode must not abandon the rest of the batch.
         for season in self.seasons:
-            for episode in season.episodes:
-                episode.syncplay()
+            season.syncplay()

--- a/src/aniworld/models/s_to/series.py
+++ b/src/aniworld/models/s_to/series.py
@@ -596,16 +596,16 @@ class SerienstreamSeries:
     # PUBLIC METHODS
     # -----------------------------
     def download(self):
+        # One failed episode must not abandon the rest of the batch.
         for season in self.seasons:
-            for episode in season.episodes:
-                episode.download()
+            season.download()
 
     def watch(self):
+        # One failed episode must not abandon the rest of the batch.
         for season in self.seasons:
-            for episode in season.episodes:
-                episode.watch()
+            season.watch()
 
     def syncplay(self):
+        # One failed episode must not abandon the rest of the batch.
         for season in self.seasons:
-            for episode in season.episodes:
-                episode.syncplay()
+            season.syncplay()

--- a/tests/test_batch_downloads.py
+++ b/tests/test_batch_downloads.py
@@ -143,3 +143,84 @@ def test_no_season_still_loops_episodes_unguarded():
         if "for episode in self.episodes:" in text:
             offenders.append(str(path.relative_to(models)))
     assert not offenders, f"unguarded batch loops: {offenders}"
+
+
+# ---------------------------------------------------------------------------
+# Series must delegate to Season, not loop episodes itself (issue #274,
+# follow-up: s_to, hanime_tv and aniworld_to still reimplemented the loop
+# at the Series level, bypassing the run_each() guard entirely)
+# ---------------------------------------------------------------------------
+class FakeSeason:
+    """A season exactly as batch-safe as the real ones: delegates to run_each."""
+
+    def __init__(self, episodes):
+        self.episodes = episodes
+
+    def download(self):
+        return run_each(self.episodes, "download")
+
+    def watch(self):
+        return run_each(self.episodes, "watch")
+
+    def syncplay(self):
+        return run_each(self.episodes, "syncplay")
+
+
+_SERIES_PROVIDERS = [
+    (
+        "aniworld.models.aniworld_to.series",
+        "AniworldSeries",
+        "https://aniworld.to/anime/stream/example-series",
+    ),
+    (
+        "aniworld.models.s_to.series",
+        "SerienstreamSeries",
+        "https://serienstream.to/serie/example-series",
+    ),
+    (
+        "aniworld.models.hanime_tv.series",
+        "HanimeTVSeries",
+        "https://hanime.tv/videos/hentai/example-video-1",
+    ),
+]
+
+
+@pytest.mark.parametrize("module_path, class_name, url", _SERIES_PROVIDERS)
+def test_series_delegates_to_season_so_one_failure_does_not_abort_the_batch(
+    monkeypatch, module_path, class_name, url
+):
+    """A single failed episode must not kill Series.download() either -
+    Series has to go through Season (which already guards with run_each()),
+    not loop season.episodes directly."""
+    import importlib
+
+    module = importlib.import_module(module_path)
+    series_cls = getattr(module, class_name)
+
+    episodes = [
+        FakeEpisode(1),
+        FakeEpisode(2, fail=ValueError("no stream found")),
+        FakeEpisode(3),
+    ]
+    fake_season = FakeSeason(episodes)
+    monkeypatch.setattr(series_cls, "seasons", property(lambda self: [fake_season]))
+
+    series = series_cls(url)
+    series.download()  # must not raise
+
+    assert all(e.ran for e in episodes), "every episode must still be attempted"
+
+
+def test_no_series_still_loops_season_episodes_unguarded():
+    """A provider added later must not reintroduce the Series-level version
+    of #274: looping season.episodes directly instead of delegating to
+    season.download()/.watch()/.syncplay()."""
+    from pathlib import Path
+
+    models = Path(__file__).resolve().parent.parent / "src" / "aniworld" / "models"
+    offenders = []
+    for path in models.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        if "for episode in season.episodes:" in text:
+            offenders.append(str(path.relative_to(models)))
+    assert not offenders, f"unguarded Series-level batch loops: {offenders}"


### PR DESCRIPTION
Series.download()/watch()/syncplay() re-implemented the episode loop that Season already handles safely via run_each() (see common/batch.py), so a single failed episode (dead hoster link, missing dub language, etc.) propagated straight out and aborted the whole --episode-file run instead of just that one episode.

cineby, kinox and burningseries already avoided this by delegating to season.download() etc.; s_to, hanime_tv and aniworld_to are now brought in line with that pattern.

Also removes a leftover print(self.to_dict()) debug line in hanime_tv/series.py::download().

Adds regression coverage: a parametrized test proving each patched Series class now survives a mid-batch episode failure, plus a static guard (mirroring the existing Season-level one) that fails the suite if any provider reintroduces 'for episode in season.episodes:' at the Series level.

Fixes #274