### PR TITLE
feat: add --raw-search and --raw-info flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-# uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
@@ -195,9 +195,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
 #   you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
@@ -217,3 +217,7 @@ __marimo__/
 
 # Docker volume mount
 /Downloads/
+
+# AI stuff
+CLAUDE.md
+.claude/

--- a/src/aniworld/arguments.py
+++ b/src/aniworld/arguments.py
@@ -183,7 +183,12 @@ def parse_args():
         metavar="QUERY",
         help="Look up a query and return the results in JSON format",
     )
-
+    discovery.add_argument(
+        "-ri",
+        "--raw-info",
+        metavar="URL",
+        help="Look up info about a movie/show from a URL",
+    )
     discovery.add_argument(
         "-sto",
         "--use-sto-search",

--- a/src/aniworld/arguments.py
+++ b/src/aniworld/arguments.py
@@ -178,10 +178,17 @@ def parse_args():
         help="Fetch a random anime series",
     )
     discovery.add_argument(
+        "-rs",
+        "--raw-search",
+        metavar="QUERY",
+        help="Look up a query and return the results in JSON format",
+    )
+
+    discovery.add_argument(
         "-sto",
         "--use-sto-search",
         action="store_true",
-        help="Prefer serienstream.to for interactive searches.",
+        help="Prefer serienstream.to for interactive searches",
     )
 
     # =========================

--- a/src/aniworld/entry.py
+++ b/src/aniworld/entry.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import sys
@@ -55,6 +56,21 @@ def aniworld():
         logger.debug("Starting AniWorld-Downloader...")
         set_terminal_title()
         args = parse_args()
+
+        if args.raw_search:
+            from .web.sitesearch import aggregate
+
+            media_type = "series" if args.use_sto_search else "movie"
+            query = args.raw_search.strip()
+            results = [
+                {"title": r["title"], "url": r["url"], "site": r["site"]}
+                for r in aggregate(query, media_type)
+            ]
+            if args.debug:
+                print(json.dumps(results, indent=2))
+            else:
+                print(results)
+            return
 
         if os.getenv("ANIWORLD_DOWNLOAD_PATH") != "/app/Downloads":
             logger.debug("Checking dependencies...")

--- a/src/aniworld/entry.py
+++ b/src/aniworld/entry.py
@@ -10,7 +10,7 @@ from .config import ACTION_METHODS, ANIWORLD_CONFIG_DIR, VERSION
 from .env import merge_env
 from .logger import get_logger
 from .models.common import run_each
-from .providers import resolve_provider
+from .providers import resolve_provider, get_info
 
 merge_env(
     Path(__file__).resolve().parent / ".env.example",
@@ -70,6 +70,12 @@ def aniworld():
                 print(json.dumps(results, indent=2))
             else:
                 print(results)
+            return
+        if args.raw_info:
+            if args.debug:
+                print(json.dumps(get_info(args.raw_info), indent=2))
+            else:
+                print(get_info(args.raw_info))
             return
 
         if os.getenv("ANIWORLD_DOWNLOAD_PATH") != "/app/Downloads":

--- a/src/aniworld/models/common/common.py
+++ b/src/aniworld/models/common/common.py
@@ -270,6 +270,9 @@ class ProviderData:
     def __getitem__(self, lang_tuple: tuple[Audio, Subtitles]):
         return self._data[lang_tuple]
 
+    def items(self):
+        return self._data.items()
+
 
 # -----------------------------------------------------------------------------
 # Episode actions (moved from models/*/episode.py)

--- a/src/aniworld/providers.py
+++ b/src/aniworld/providers.py
@@ -16,6 +16,8 @@ from .config import (
     FILMPALAST_SERIES_PATTERN,
     HANIME_TV_SERIES_PATTERN,
     KINOX_SERIES_PATTERN,
+    LANG_KEY_MAP,
+    LANG_LABELS,
     MANGA_FIRE_CHAPTER_PATTERN,
     MANGA_FIRE_SERIES_PATTERN,
     MEGAKINO_SERIES_PATTERN,
@@ -184,6 +186,52 @@ def _serialize_episode(episode) -> dict:
     return {attr: getattr(episode, attr) for attr in _EPISODE_ATTRS if hasattr(episode, attr)}
 
 
+# Keyed by enum *values*, not by the enums themselves: several site modules
+# (models/s_to/episode.py, …) declare their own Audio/Subtitles enums, so the
+# members in provider_data are not the ones config.py defines.
+_STREAM_LABELS = {
+    (audio.value, subtitles.value): LANG_LABELS[key]
+    for key, (audio, subtitles) in LANG_KEY_MAP.items()
+}
+
+
+def _serialize_streams(episode) -> dict:
+    """
+    Available streams as {"<language label>": ["VOE", "Filemoon", ...]}.
+
+    Both names are usable verbatim on the CLI: the key as --language, the
+    entries as --provider. No URLs, because neither flag accepts one
+    (--provider-url is a separate, single-episode escape hatch).
+    """
+    from .extractors import provider_functions
+
+    try:
+        data = getattr(episode, "provider_data", None) or {}
+        streams = {}
+        for (audio, subtitles), providers in data.items():
+            label = _STREAM_LABELS.get((audio.value, subtitles.value))
+            if label is None:
+                label = (
+                    f"{audio.value} Dub"
+                    if subtitles.value == "None"
+                    else f"{subtitles.value} Sub"
+                )
+            # serienstream.to lists hosters we have no extractor for (including
+            # one literally named "Provider"); offering them would only produce
+            # a download that cannot resolve.
+            named = [
+                name
+                for name in providers
+                if f"get_direct_link_from_{name.lower()}" in provider_functions
+            ]
+            if named:
+                streams[label] = sorted(named)
+    except Exception:
+        # One unreachable episode page must not sink the whole info dump.
+        return {}
+    return streams
+
+
 def get_info(url):
     provider = resolve_provider(url)
     media = provider.series_cls(url)
@@ -191,16 +239,35 @@ def get_info(url):
     if provider.season_cls is None:
         # Movie-only providers (MegaKino, FilmPalast): series_cls IS the
         # episode/movie itself, no season/episode hierarchy to walk.
-        episodes = {"1": [_serialize_episode(media)]}
+        seasons = [(None, [media])]
     else:
-        episodes = {
-            str(season.season_number): [_serialize_episode(ep) for ep in season.episodes]
-            for season in media.seasons
-        }
+        seasons = [(season.url, list(season.episodes)) for season in media.seasons]
 
-    return {
-        "name": media.title,
-        "provider": provider.name,
-        "episodes": episodes,
-        "url": url,
-    }
+    content = [url]
+    entries = []
+
+    for season_url, episodes in seasons:
+        season_entries = []
+        for episode in episodes:
+            entry = _serialize_episode(episode)
+            entry["streams"] = _serialize_streams(episode)
+            season_entries.append(entry)
+        entries.extend(season_entries)
+
+        if season_url is None:
+            content.extend(season_entries)
+        else:
+            content.append([season_url, *season_entries])
+
+    info = {"name": media.title, "provider": provider.name}
+
+    # Nearly every show offers the same streams on every episode; only repeat
+    # them per episode when they actually differ.
+    streams = [entry["streams"] for entry in entries]
+    if not streams or all(s == streams[0] for s in streams):
+        for entry in entries:
+            del entry["streams"]
+        info["streams"] = streams[0] if streams else {}
+
+    info["content"] = content
+    return info

--- a/src/aniworld/providers.py
+++ b/src/aniworld/providers.py
@@ -175,3 +175,32 @@ def resolve_provider(url: str) -> Provider:
             return provider
 
     raise ValueError(f"Unsupported URL: {url}")
+
+
+_EPISODE_ATTRS = ("url", "title", "title_de", "title_en", "episode_number")
+
+
+def _serialize_episode(episode) -> dict:
+    return {attr: getattr(episode, attr) for attr in _EPISODE_ATTRS if hasattr(episode, attr)}
+
+
+def get_info(url):
+    provider = resolve_provider(url)
+    media = provider.series_cls(url)
+
+    if provider.season_cls is None:
+        # Movie-only providers (MegaKino, FilmPalast): series_cls IS the
+        # episode/movie itself, no season/episode hierarchy to walk.
+        episodes = {"1": [_serialize_episode(media)]}
+    else:
+        episodes = {
+            str(season.season_number): [_serialize_episode(ep) for ep in season.episodes]
+            for season in media.seasons
+        }
+
+    return {
+        "name": media.title,
+        "provider": provider.name,
+        "episodes": episodes,
+        "url": url,
+    }

--- a/src/aniworld/web/sitesearch.py
+++ b/src/aniworld/web/sitesearch.py
@@ -10,15 +10,16 @@ import re
 from ..logger import get_logger
 from ..models.mangafire_to.series import search_series as query_mangafire
 from ..search import (
-    query as query_aniworld,
-)
-from ..search import (
+    _relevance_score,
     query_burningseries,
     query_cineby,
     query_filmpalast,
     query_kinox,
     query_megakino,
     query_s_to,
+)
+from ..search import (
+    query as query_aniworld,
 )
 
 logger = get_logger(__name__)
@@ -127,6 +128,5 @@ def aggregate(title, media_type, per_site=8, limit=25):
     for site in sites_for(media_type):
         for item in search(site, title)[:per_site]:
             combined.append({**item, "site": site})
-            if len(combined) >= limit:
-                return combined
-    return combined
+    combined.sort(key=lambda item: _relevance_score(item["title"], title))
+    return combined[:limit]

--- a/tests/test_get_info.py
+++ b/tests/test_get_info.py
@@ -1,0 +1,101 @@
+from aniworld import providers
+from aniworld.config import Audio, Subtitles
+
+
+class FakeEpisode:
+    def __init__(self, url, episode_number, provider_data):
+        self.url = url
+        self.title_de = f"DE {episode_number}"
+        self.title_en = f"EN {episode_number}"
+        self.episode_number = episode_number
+        self.provider_data = provider_data
+
+
+class FakeSeason:
+    def __init__(self, url, episodes):
+        self.url = url
+        self.episodes = episodes
+
+
+class FakeSeries:
+    title = "Andor"
+
+    def __init__(self, seasons):
+        self.seasons = seasons
+
+
+def _patch(monkeypatch, seasons, season_cls=object):
+    provider = providers.Provider(
+        name="SerienStream",
+        series_pattern=None,
+        season_pattern=None,
+        episode_pattern=None,
+        series_cls=lambda url: FakeSeries(seasons),
+        season_cls=season_cls,
+        episode_cls=object,
+    )
+    monkeypatch.setattr(providers, "resolve_provider", lambda url: provider)
+
+
+GERMAN = {(Audio.GERMAN, Subtitles.NONE): {"VOE": "u1", "Filemoon": "u2"}}
+ENGLISH = {(Audio.JAPANESE, Subtitles.ENGLISH): {"Doodstream": "u3"}}
+
+SERIES_URL = "https://serienstream.to/serie/andor"
+SEASON_URL = f"{SERIES_URL}/staffel-1"
+
+
+def _episode(number, provider_data):
+    return FakeEpisode(f"{SEASON_URL}/episode-{number}", number, provider_data)
+
+
+def test_uniform_streams_are_hoisted_to_the_show(monkeypatch):
+    season = FakeSeason(SEASON_URL, [_episode(1, GERMAN), _episode(2, GERMAN)])
+    _patch(monkeypatch, [season])
+
+    info = providers.get_info(SERIES_URL)
+
+    assert info["streams"] == {"German Dub": ["Filemoon", "VOE"]}
+    assert info["content"][0] == SERIES_URL
+    assert info["content"][1][0] == SEASON_URL
+    assert info["content"][1][1] == {
+        "url": f"{SEASON_URL}/episode-1",
+        "title_de": "DE 1",
+        "title_en": "EN 1",
+        "episode_number": 1,
+    }
+    assert "url" not in info
+
+
+def test_differing_streams_stay_on_the_episodes(monkeypatch):
+    season = FakeSeason(SEASON_URL, [_episode(1, GERMAN), _episode(2, ENGLISH)])
+    _patch(monkeypatch, [season])
+
+    info = providers.get_info(SERIES_URL)
+
+    assert "streams" not in info
+    assert info["content"][1][1]["streams"] == {"German Dub": ["Filemoon", "VOE"]}
+    assert info["content"][1][2]["streams"] == {"English Sub": ["Doodstream"]}
+
+
+def test_movie_provider_has_no_season_nesting(monkeypatch):
+    movie = FakeEpisode("https://megakino.co/film/x", 1, GERMAN)
+    movie.title = "Movie"
+    monkeypatch.setattr(
+        providers,
+        "resolve_provider",
+        lambda url: providers.Provider(
+            name="MegaKino",
+            series_pattern=None,
+            season_pattern=None,
+            episode_pattern=None,
+            series_cls=lambda u: movie,
+            season_cls=None,
+            episode_cls=object,
+        ),
+    )
+
+    info = providers.get_info("https://megakino.co/film/x")
+
+    assert info["content"][0] == "https://megakino.co/film/x"
+    assert info["content"][1]["episode_number"] == 1
+    assert info["streams"] == {"German Dub": ["Filemoon", "VOE"]}

--- a/tests/test_search_parsers.py
+++ b/tests/test_search_parsers.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from aniworld import search
+from aniworld.web import sitesearch
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -168,3 +169,34 @@ def test_every_card_has_the_fields_the_ui_needs(genre_page):
     for item in search.fetch_genre_animes("mecha")["results"]:
         assert set(item) == {"title", "url", "genre", "poster_url"}
         assert item["title"] and item["url"]
+
+
+def test_aggregate_sorts_by_relevance_across_sites(monkeypatch):
+    per_site = {
+        "sto": [{"title": "Zulu Robot", "url": "u1", "poster": ""}],
+        "burningseries": [],
+        "aniworld": [],
+        "kinox": [{"title": "Mr. Robot", "url": "u2", "poster": ""}],
+        "cineby": [{"title": "Mr. Robot Behind the Mask", "url": "u3", "poster": ""}],
+    }
+    monkeypatch.setattr(sitesearch, "search", lambda site, keyword: per_site[site])
+
+    results = sitesearch.aggregate("Mr. Robot", "series")
+
+    # Later sites must still be reachable, and the exact hit must come first.
+    assert [item["url"] for item in results] == ["u2", "u3", "u1"]
+
+
+def test_aggregate_respects_limit(monkeypatch):
+    monkeypatch.setattr(
+        sitesearch,
+        "search",
+        lambda site, keyword: [
+            {"title": f"{site} {i}", "url": f"{site}{i}", "poster": ""}
+            for i in range(10)
+        ],
+    )
+
+    results = sitesearch.aggregate("x", "series", per_site=8, limit=25)
+
+    assert len(results) == 25


### PR DESCRIPTION
Adds two discovery flags: `--raw-search` for querying a movie/show by name, and
`--raw-info` for pulling structured info (title, provider, available streams,
seasons/episodes) from a given URL. Both print JSON to stdout.

## `--raw-search` / `-rs`

Searches for a movie or show with a user-given query.

```sh
python -m aniworld -d -rs "mr robot" -sto
```

**Features**
- Searches movies and shows, plus serienstream.to if `-sto` is given
- Returns title, URL, and site of each result
- Sorts results by relevancy
- Pretty-prints when debug mode is active
- Reuses the existing `aggregate` function
- Test coverage in `tests/test_search_parsers.py`

**Example output** (debug mode; without `-d` it is the raw Python list on one line)

```json
[
  {
    "title": "Mr. Robot",
    "url": "https://serienstream.to/serie/mr-robot",
    "site": "sto"
  },
  {
    "title": "Mr. Robot (2015)",
    "url": "https://www.cineby.at/tv/62560",
    "site": "cineby"
  },
  {
    "title": "Mr.Robot (2025)",
    "url": "https://www.cineby.at/movie/1414052",
    "site": "cineby"
  }
]
```

## `--raw-info` / `-ri`

Looks up a movie/show from a URL and returns its title, provider, available
streams, and the season/episode tree.

```sh
python -m aniworld -d -ri "https://aniworld.to/anime/stream/dan-da-dan"
```

```json
{
  "name": "DAN DA DAN",
  "provider": "AniWorld",
  "streams": {
    "German Dub": ["Doodstream", "Filemoon", "VOE", "Vidmoly"],
    "English Sub": ["Doodstream", "Filemoon", "VOE", "Vidmoly"],
    "German Sub": ["Doodstream", "Filemoon", "VOE", "Vidmoly"]
  },
  "content": [
    "https://aniworld.to/anime/stream/dan-da-dan",
    [
      "https://aniworld.to/anime/stream/dan-da-dan/staffel-1",
      {
        "url": "https://aniworld.to/anime/stream/dan-da-dan/staffel-1/episode-1",
        "title_de": "Wenn das mal nicht der Anfang einer Liebe ist",
        "title_en": "That's How Love Starts, Ya Know!",
        "episode_number": 1
      },
      ...
    ]
  ]
}
```

### `content`

One flat, positional structure instead of a URL field plus a season-number dict:

- `content[0]` is the series URL.
- Every following entry is one season, itself a list whose first element is the
  season URL and whose remaining elements are the episodes, in order. Season
  numbers were dropped as keys because they are already the list position and
  are still readable off the season URL.
- Movie-only providers (MegaKino, FilmPalast) have no season/episode hierarchy,
  so the movie is serialized directly as `content[1]` with no season nesting.

### `streams`

`streams` maps a language label to the hosters that carry it. Both names are
usable verbatim on the CLI — the key as `--language`, an entry as `--provider`:

```sh
aniworld --no-menu --language "German Dub" --provider VOE "<url>"
```

No URLs are included, because neither flag takes one (`--provider-url` is a
separate single-episode escape hatch, not something derivable from this dump).

Availability usually holds for a whole show, so `streams` sits at the top level
when every episode offers the same thing. When episodes actually differ, the
top-level key is omitted and each episode carries its own `streams` instead —
e.g. serienstream's Cyberpunk: Edgerunners, where episodes 3 and 9 are
VOE-only while the rest also have Doodstream.

Hosters we have no extractor for are filtered out (serienstream lists several,
including one literally named `"Provider"`); offering them would only produce a
download that cannot resolve. Same check `models/megakino` already applies.

Two bugs surfaced while building this:

- `models/s_to/episode.py` declares its *own* `Audio`/`Subtitles` enums, so the
  members in its `provider_data` are not the ones `config.py` defines and every
  `INVERSE_LANG_KEY_MAP` lookup missed — labels came out as `"None Sub"`. Stream
  labels are now matched on the enum *values*.
- `ProviderData` had no `items()`, only `get()`/`__getitem__`, so it could not be
  iterated like the plain dicts the other sites return. Added.

Test coverage in `tests/test_get_info.py`: uniform streams hoisted to the show,
differing streams kept per episode, and the movie-provider shape.

## Other edits

- Changed result sorting from alphabetical to relevancy in `aggregate`
- Added `uv.lock` and coding-agent files (`CLAUDE.md`, `.claude/`) to `.gitignore`
- Removed unfitting dot in `arguments.py`
- `prettier` auto-removed two stray spaces in `.gitignore`

(this is written by claude bc im a horrible writer)